### PR TITLE
User consent storing of public clients

### DIFF
--- a/tunnistamo/urls.py
+++ b/tunnistamo/urls.py
@@ -12,6 +12,9 @@ from oidc_apis.views import get_api_tokens_view
 from users.views import EmailNeededView, LoginView, LogoutView
 
 from .api import GetJWTView, UserView
+from .oidc import patch_oidc_provider_user_consent_handling
+
+patch_oidc_provider_user_consent_handling()
 
 
 def show_login(request):


### PR DESCRIPTION
Patch the `get` method of oidc_provider.views.AuthorizeView so that it
allows using stored user consents.

This is needed, because Django OIDC Provider doesn't allow stored User
Consent to be used if client type is public.

This hack replaces the value "public" with another value while doing the
authorize request in django_oidc and finally restores the original
value.