### PR TITLE
Use forked version of django-oidc-provider

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ django-multiselectfield
 django-oauth-toolkit
 django-parler
 django-cors-headers
-django-oidc-provider
+git+git://github.com/City-of-Helsinki/django-oidc-provider.git@v0.5.0.post1+uc#egg=django-oidc-provider==0.5.0.post1+uc
 djangorestframework
 pyjwt
 django-helusers

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-helusers==0.3.1
 django-multiselectfield==0.1.7
 django-npm==1.0.0
 django-oauth-toolkit==1.0.0
-django-oidc-provider==0.5.0
+git+git://github.com/City-of-Helsinki/django-oidc-provider.git@v0.5.0.post1+uc#egg=django-oidc-provider==0.5.0.post1+uc
 django-parler==1.8
 django-sass-processor==0.5.4
 djangorestframework==3.6.3


### PR DESCRIPTION
Switch our django-oidc-provider dependency to use a forked release again
to support storing and reusing user consents for public clients
too (when using the Implicit Flow).

This is needed until juanifioren/django-oidc-provider#189 is merged and
released.

Alternative would be quite horrible monkey patching hack as can be seen
in the PR #22.