### PR TITLE
Fix copy-paste bug

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -40,7 +40,7 @@ class LoginView(TemplateView):
 
                 try:
                     oidc_client = Client.objects.get(client_id=client_id)
-                except get_application_model().DoesNotExist:
+                except Client.DoesNotExist:
                     pass
 
             next_url = quote(next_url)


### PR DESCRIPTION
I kept the DoesNotExist style because it's more explicit for the reader. Also, the search for an application already uses the same pattern.