### PR TITLE
Tests for "devices" and "identities" apps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,7 @@ script:
   - isort -c
   - pytest -ra -vvv --cov=.
 
+addons:
+  postgresql: '9.6'
+
 after_success: codecov

--- a/auth_backends/adfs/tests/test_helsinki_adfs_backend.py
+++ b/auth_backends/adfs/tests/test_helsinki_adfs_backend.py
@@ -9,7 +9,6 @@ from jwt import DecodeError
 
 from auth_backends.adfs.helsinki import HelsinkiADFS
 
-
 ACCESS_TOKEN = ("""
 eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6InpmU1lDZThYTnpNY
 kJLTmxvLWFUYmdDOUo1cyJ9.eyJhdWQiOiJodHRwczovL2FwaS5oZWwuZmkvc

--- a/devices/api.py
+++ b/devices/api.py
@@ -8,15 +8,11 @@ from rest_framework.mixins import CreateModelMixin, DestroyModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 
-from tunnistamo.api_common import OidcTokenAuthentication
+from tunnistamo.api_common import OidcTokenAuthentication, ScopePermission
 
 from .models import UserDevice
 
 logger = logging.getLogger(__name__)
-
-
-class DeviceScopeAuthentication(OidcTokenAuthentication):
-    scopes_needed = ['devices']
 
 
 def generate_secret_key():
@@ -36,10 +32,6 @@ class PublicKeySerializer(serializers.Serializer):
 
     def to_representation(self, instance):
         return instance
-
-    def validate(self, data):
-        # TODO
-        return data
 
 
 class UserDeviceSerializer(serializers.ModelSerializer):
@@ -62,8 +54,9 @@ class UserDeviceSerializer(serializers.ModelSerializer):
 class UserDeviceViewSet(CreateModelMixin, DestroyModelMixin, GenericViewSet):
     queryset = UserDevice.objects.all()
     serializer_class = UserDeviceSerializer
-    authentication_classes = (DeviceScopeAuthentication,)
-    permission_classes = (IsAuthenticated,)
+    authentication_classes = (OidcTokenAuthentication,)
+    permission_classes = (IsAuthenticated, ScopePermission)
+    required_scopes = ('devices',)
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)

--- a/devices/factories.py
+++ b/devices/factories.py
@@ -1,0 +1,21 @@
+import factory
+
+from devices.models import InterfaceDevice, UserDevice
+from tunnistamo.factories import UserFactory
+
+
+class UserDeviceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = UserDevice
+
+    user = factory.SubFactory(UserFactory)
+    public_key = {'foo': 'bar'}
+    secret_key = {'foo': 'bar'}
+    app_version = '0.1.0'
+    os = UserDevice.OS_ANDROID
+    os_version = '8.1'
+
+
+class InterfaceDeviceFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = InterfaceDevice

--- a/devices/tests/conftest.py
+++ b/devices/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()

--- a/devices/tests/test_api.py
+++ b/devices/tests/test_api.py
@@ -1,0 +1,187 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from devices.factories import UserDeviceFactory
+from devices.models import UserDevice
+from tunnistamo.factories import UserFactory, access_token_factory
+
+list_url = reverse('v1:userdevice-list')
+
+
+def get_user_device_detail_url(user_device):
+    return reverse('v1:userdevice-detail', kwargs={'pk': user_device.pk})
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def user():
+    return UserFactory()
+
+
+@pytest.fixture
+def user_api_client(user):
+    api_client = APIClient()
+    token = access_token_factory(scopes=['devices'], user=user)
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(token.access_token))
+    api_client.token = token
+    api_client.user = user
+    return api_client
+
+
+@pytest.fixture
+def post_data():
+    return {
+        'public_key': {
+            'kty': 'EC',
+            'use': 'sig',
+            'crv': 'P-256',
+            'alg': 'ES256',
+            'x': 'UdTokfffnUeczbK2-7QuBq_YaDgXek6IreqhGZ1cR4s',
+            'y': 'NBJKDLcZejGp1msCzHRNopykrEbktsqWsk4hGdr6gPk'
+        },
+        'secret_key': {  # should be ignored
+            'k': 'foo',
+            'use': 'enc',
+            'kty': 'oct',
+            'alg': 'HS256'
+        },
+        'os': 'android',
+        'os_version': '7.1',
+        'app_version': '0.1.0',
+        'device_model': 'LG G5',
+        'auth_counter': 7,  # should be ignored
+    }
+
+
+# TESTS BEGIN HERE #
+
+
+@pytest.mark.parametrize('scopes', (['devices'], ['another_scope', 'devices']))
+@pytest.mark.django_db
+def test_authentication_success(api_client, scopes, post_data):
+    access_token_factory(scopes=scopes)
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer test_access_token')
+    response = api_client.post(list_url, post_data)
+    assert response.status_code != 401
+
+
+@pytest.mark.django_db
+def test_authentication_wrong_access_token(api_client, post_data):
+    access_token_factory(scopes=['devices'])
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer wrong_access_token')
+    response = api_client.post(list_url)
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize('scopes', (['device'], ['device', 'another_wrong_scope']))
+@pytest.mark.django_db
+def test_authentication_wrong_scope(api_client, scopes, post_data):
+    access_token_factory(scopes=scopes)
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer test_access_token')
+    response = api_client.post(list_url, post_data)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('method', ('get', 'put', 'patch', 'delete'))
+def test_nonallowed_methods_list(user_api_client, method):
+    response = getattr(user_api_client, method)(list_url)
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('method', ('get', 'put', 'patch'))
+def test_nonallowed_methods_detail(user_api_client, method):
+    url = get_user_device_detail_url(UserDeviceFactory())
+    response = getattr(user_api_client, method)(url)
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_post_user_device(user_api_client, post_data):
+    response = user_api_client.post(list_url, post_data)
+    assert response.status_code == 201
+
+    assert UserDevice.objects.count() == 1
+    new_user_device = UserDevice.objects.first()
+
+    assert len(response.data) == 9
+    assert response.data['id'] == str(new_user_device.id)
+    assert response.data['user'] == user_api_client.user.uuid
+    assert response.data['public_key'] == post_data['public_key']
+    assert response.data['os'] == 'android'
+    assert response.data['os_version'] == '7.1'
+    assert response.data['app_version'] == '0.1.0'
+    assert response.data['device_model'] == 'LG G5'
+    assert response.data['secret_key'] == new_user_device.secret_key
+    assert response.data['auth_counter'] == 0
+
+    assert new_user_device.user == user_api_client.user
+    assert new_user_device.os == 'android'
+    assert new_user_device.os_version == '7.1'
+    assert new_user_device.app_version == '0.1.0'
+    assert new_user_device.device_model == 'LG G5'
+    assert new_user_device.last_used_at
+    assert new_user_device.auth_counter == 0
+    assert new_user_device.secret_key['k'] != 'foo'
+
+
+@pytest.mark.django_db
+def test_delete_user_device(user_api_client):
+    user_device = UserDeviceFactory(user=user_api_client.user)
+    url = get_user_device_detail_url(user_device)
+
+    response = user_api_client.delete(url)
+    assert response.status_code == 204
+
+    assert UserDevice.objects.count() == 0
+
+    response = user_api_client.delete(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_delete_user_device_wrong_user(user_api_client):
+    other_user = UserFactory()
+    user_device = UserDeviceFactory(user=other_user)
+    url = get_user_device_detail_url(user_device)
+
+    response = user_api_client.delete(url)
+    assert response.status_code == 403
+
+    assert UserDevice.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_post_user_device_check_required_fields(user_api_client):
+    response = user_api_client.post(list_url, {})
+    assert response.status_code == 400
+    assert set(response.data) == {'public_key', 'os', 'os_version', 'app_version'}
+
+
+@pytest.mark.django_db
+def test_post_user_device_check_public_key_required_fields(user_api_client, post_data):
+    post_data['public_key'] = {}
+    response = user_api_client.post(list_url, post_data)
+    assert response.status_code == 400
+    assert set(response.data['public_key']) == {'kty', 'use', 'crv', 'alg', 'x', 'y'}
+
+
+@pytest.mark.django_db
+def test_post_user_device_check_public_key_kty_use_crv_alg(user_api_client, post_data):
+    post_data['public_key'] = {
+        'kty': 'ECXXX',
+        'use': 'sigXXX',
+        'crv': 'P-256XXX',
+        'alg': 'ES256XXX',
+        'x': 'UdTokfffnUeczbK2-7QuBq_YaDgXek6IreqhGZ1cR4s',
+        'y': 'NBJKDLcZejGp1msCzHRNopykrEbktsqWsk4hGdr6gPk'
+    }
+    response = user_api_client.post(list_url, post_data)
+    assert response.status_code == 400
+    assert set(response.data['public_key']) == {'kty', 'use', 'crv', 'alg'}

--- a/identities/api.py
+++ b/identities/api.py
@@ -7,7 +7,7 @@ from rest_framework.mixins import CreateModelMixin, DestroyModelMixin, ListModel
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import GenericViewSet
 
-from tunnistamo.api_common import OidcTokenAuthentication, DeviceGeneratedJWTAuthentication, ScopePermission
+from tunnistamo.api_common import DeviceGeneratedJWTAuthentication, OidcTokenAuthentication, ScopePermission
 
 from .helmet_requests import (
     HelmetConnectionException, HelmetGeneralException, HelmetImproperlyConfiguredException, validate_patron

--- a/identities/factories.py
+++ b/identities/factories.py
@@ -1,0 +1,13 @@
+import factory
+
+from identities.models import UserIdentity
+from tunnistamo.factories import UserFactory
+
+
+class UserIdentityFactory(factory.django.DjangoModelFactory):
+    service = UserIdentity.SERVICE_HELMET
+    user = factory.SubFactory(UserFactory)
+    identifier = factory.Faker('ean13')
+
+    class Meta:
+        model = UserIdentity

--- a/identities/helmet_requests.py
+++ b/identities/helmet_requests.py
@@ -105,5 +105,5 @@ def _create_api_url(endpoint):
 def _get_setting(setting_name):
     value = getattr(settings, setting_name, None)
     if value is None:
-        raise HelmetImproperlyConfiguredException('Setting {} not set.')
+        raise HelmetImproperlyConfiguredException('Setting {} not set.'.format(setting_name))
     return value

--- a/identities/tests/test_api.py
+++ b/identities/tests/test_api.py
@@ -1,0 +1,290 @@
+import json
+import random
+import time
+import uuid
+from unittest import mock
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from jwcrypto import jwe, jwk, jws
+from jwcrypto.common import json_encode
+from rest_framework.test import APIClient
+
+from devices.factories import InterfaceDeviceFactory, UserDeviceFactory
+from identities.factories import UserFactory, UserIdentityFactory
+from identities.helmet_requests import HelmetConnectionException
+from identities.models import UserIdentity
+from tunnistamo.factories import access_token_factory
+
+User = get_user_model()
+
+list_url = reverse('v1:useridentity-list')
+
+
+def get_user_identity_detail_url(user_identity):
+    return reverse('v1:useridentity-detail', kwargs={'pk': user_identity.pk})
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def post_data():
+    return {
+        'service': 'helmet',
+        'identifier': '4319471412',
+        'secret': '1234',
+    }
+
+
+@pytest.fixture
+def user():
+    return UserFactory()
+
+
+@pytest.fixture
+def user_api_client(user):
+    api_client = APIClient()
+    token = access_token_factory(scopes=['identities'], user=user)
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(token.access_token))
+    api_client.token = token
+    api_client.user = user
+    return api_client
+
+
+def create_jwe(header, payload, sign_key, enc_key):
+    jws_token = jws.JWS(json_encode(payload))
+    jws_token.add_signature(sign_key, None, json_encode({'alg': 'ES256'}))
+
+    jwe_token = jwe.JWE(jws_token.serialize(compact=True), json_encode(header))
+    jwe_token.add_recipient(enc_key)
+
+    return jwe_token.serialize(compact=True)
+
+
+@pytest.fixture
+def interface_device_api_client(user):
+    api_client = APIClient()
+
+    enc_key = jwk.JWK.generate(kty='oct', alg='HS256', use='enc')
+    sign_key = jwk.JWK.generate(kty='EC', crv='P-256', use='sig')
+
+    user_device = UserDeviceFactory(
+        secret_key=json.loads(enc_key.export()),
+        public_key=json.loads(sign_key.export_public()),
+        user=user,
+    )
+    interface_device = InterfaceDeviceFactory(secret_key=str(uuid.uuid4()), scopes='read:identities:helmet')
+
+    header = {'alg': 'A256KW', 'enc': 'A128CBC-HS256', 'iss': str(user_device.id)}
+    payload = {
+        'iss': str(user_device.id),
+        'cnt': user_device.auth_counter + 1,
+        'azp': str(interface_device.id),
+        'sub': str(user.uuid),
+        'iat': int(time.time()),
+        'nonce': int(random.random()*1000000000000000),
+    }
+
+    token = create_jwe(header, payload, sign_key, enc_key)
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(token),
+                           HTTP_X_INTERFACE_DEVICE_SECRET=str(interface_device.secret_key))
+
+    api_client.user_device = user_device
+    api_client.interface_device = interface_device
+    api_client.token = token
+    api_client.user = user_device.user
+
+    return api_client
+
+
+@pytest.fixture(params=('user_api_client', 'interface_device_api_client'))
+def both_api_clients(user_api_client, interface_device_api_client, request):
+    return (user_api_client, interface_device_api_client)[request.param_index]
+
+
+# TESTS BEGIN HERE #
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('method', ('put', 'patch', 'delete'))
+def test_not_allowed_methods_list(both_api_clients, method):
+    response = getattr(both_api_clients, method)(list_url)
+    assert response.status_code in (403, 405)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('method', ('get',))
+def test_not_allowed_methods_detail(both_api_clients, method):
+    user_identity = UserIdentityFactory(user=both_api_clients.user)
+    url = get_user_identity_detail_url(user_identity)
+    response = getattr(both_api_clients, method)(url)
+    assert response.status_code in (403, 405)
+
+
+@pytest.mark.parametrize('scopes', (['identities'], ['another_scope', 'identities']))
+@pytest.mark.django_db
+def test_access_token_authentication(api_client, scopes):
+    access_token_factory(scopes=scopes)
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer test_access_token')
+    response = api_client.get(list_url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_access_token_authentication_wrong_access_token(api_client):
+    access_token_factory(scopes=['identities'])
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer wrong_access_token')
+    response = api_client.get(list_url)
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize('scopes', (['foo'], ['foo', 'another_wrong_scope']))
+@pytest.mark.django_db
+def test_access_token_authentication_wrong_scope(api_client, scopes):
+    access_token_factory(scopes=scopes)
+    api_client.credentials(HTTP_AUTHORIZATION='Bearer test_access_token')
+    response = api_client.get(list_url)
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_interface_device_authentication(interface_device_api_client):
+    user_device = interface_device_api_client.user_device
+    old_last_used_at = user_device.last_used_at
+    old_auth_counter = user_device.auth_counter
+
+    response = interface_device_api_client.get(list_url)
+    assert response.status_code == 200
+
+    user_device.refresh_from_db()
+    assert user_device.last_used_at > old_last_used_at
+    assert user_device.auth_counter == old_auth_counter + 1
+
+
+@pytest.mark.django_db
+def test_interface_device_authentication_repeat(interface_device_api_client):
+    response = interface_device_api_client.get(list_url)
+    assert response.status_code == 200
+
+    response = interface_device_api_client.get(list_url)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_interface_device_authentication_wrong_client_secret(interface_device_api_client):
+    interface_device_api_client.credentials(HTTP_AUTHORIZATION='Bearer {}'.format(interface_device_api_client.token),
+                                            HTTP_X_INTERFACE_DEVICE_SECRET='bogus123')
+    response = interface_device_api_client.get(list_url)
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+@mock.patch('identities.api.validate_patron', return_value=True)
+def test_post_user_identity(validate_patron, user_api_client, post_data):
+    response = user_api_client.post(list_url, post_data)
+    assert response.status_code == 201
+    validate_patron.assert_called_with(post_data['identifier'], post_data['secret'])
+
+    new_user_identity = UserIdentity.objects.first()
+
+    assert len(response.data) == 3
+    assert response.data['service'] == 'helmet'
+    assert response.data['identifier'] == '4319471412'
+    assert response.data['id'] == new_user_identity.id
+
+    assert new_user_identity.service == 'helmet'
+    assert new_user_identity.identifier == '4319471412'
+    assert new_user_identity.user == user_api_client.user
+
+
+@pytest.mark.django_db
+@mock.patch('identities.api.validate_patron', return_value=True)
+def test_post_user_identity_interface_device(validate_patron, interface_device_api_client, post_data):
+    response = interface_device_api_client.post(list_url, post_data)
+    assert response.status_code == 403
+    validate_patron.not_called()
+    assert UserIdentity.objects.count() == 0
+
+
+@pytest.mark.django_db
+@mock.patch('identities.api.validate_patron')
+def test_post_user_identity_check_required_fields(validate_patron, user_api_client):
+    response = user_api_client.post(list_url, {})
+    assert response.status_code == 400
+    assert set(response.data) == {'service', 'identifier', 'secret'}
+    assert validate_patron.not_called()
+
+
+@pytest.mark.django_db
+@mock.patch('identities.api.validate_patron')
+def test_post_user_identity_invalid_service(validate_patron, user_api_client, post_data):
+    post_data['service'] = 'methel'
+
+    response = user_api_client.post(list_url, post_data)
+    assert response.status_code == 400
+    assert len(response.data) == 1
+    assert response.data['service']
+    assert validate_patron.not_called()
+
+
+@pytest.mark.django_db
+@mock.patch('identities.api.validate_patron', return_value=False)
+def test_post_user_identity_invalid_secret(validate_patron, user_api_client, post_data):
+    response = user_api_client.post(list_url, post_data)
+    assert response.status_code == 401
+
+    assert len(response.data) == 2
+    assert response.data['code'] == 'invalid_credentials'
+    assert response.data['detail']
+
+
+@pytest.mark.django_db
+@mock.patch('identities.api.validate_patron', side_effect=HelmetConnectionException)
+def test_post_user_identity_connection_error(validate_patron, user_api_client, post_data):
+    response = user_api_client.post(list_url, post_data)
+    assert response.status_code == 401
+
+    assert len(response.data) == 2
+    assert response.data['code'] == 'authentication_service_unavailable'
+    assert response.data['detail']
+
+
+@pytest.mark.django_db
+def test_delete_user_identity(user_api_client):
+    user_identity = UserIdentityFactory(user=user_api_client.user)
+    url = get_user_identity_detail_url(user_identity)
+
+    response = user_api_client.delete(url)
+    assert response.status_code == 204
+
+    assert UserIdentity.objects.count() == 0
+
+    response = user_api_client.delete(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_delete_user_identity_wrong_user(user_api_client):
+    other_user = UserFactory()
+    user_identity = UserIdentityFactory(user=other_user)
+    url = get_user_identity_detail_url(user_identity)
+
+    response = user_api_client.delete(url)
+    assert response.status_code == 404
+
+    assert UserIdentity.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_delete_user_identity_interface_device(interface_device_api_client):
+    user_identity = UserIdentityFactory(user=interface_device_api_client.user)
+    url = get_user_identity_detail_url(user_identity)
+
+    response = interface_device_api_client.delete(url)
+    assert response.status_code == 403
+
+    assert UserIdentity.objects.count() == 1

--- a/identities/tests/test_helmet_requests.py
+++ b/identities/tests/test_helmet_requests.py
@@ -1,0 +1,149 @@
+from unittest import mock
+
+import pytest
+from requests.exceptions import RequestException
+
+from identities.helmet_requests import HelmetConnectionException, HelmetImproperlyConfiguredException, validate_patron
+
+
+class DummyResponse:
+    status_code = None
+    exception = None
+
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+    def json(self):
+        return {}
+
+    def raise_for_status(self):
+        if self.exception:
+            raise self.exception
+
+    @property
+    def text(self):
+        return str(self.json())
+
+
+class DummyTokenResponse(DummyResponse):
+    status_code = 200
+    access_token = 'test_access_token'
+    expires_in = 3600
+
+    def json(self):
+        return {
+            'access_token': self.access_token,
+            'expires_in': self.expires_in,
+        }
+
+
+class DummyValidatePatronFailedResponse(DummyResponse):
+    status_code = 400
+    code = 108
+
+    def json(self):
+        return {
+            'code': self.code
+        }
+
+
+@pytest.fixture(autouse=True)
+def override_settings(settings):
+    settings.HELMET_API_BASE_URL = 'http://api.test.com/v1/'
+    settings.HELMET_API_USERNAME = 'test_helmet_api_username'
+    settings.HELMET_API_PASSWORD = 'test_helmet_api_password'
+
+    settings.CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
+        }
+    }
+
+
+@pytest.mark.parametrize('missing_setting', (
+    'HELMET_API_BASE_URL',
+    'HELMET_API_USERNAME',
+    'HELMET_API_PASSWORD',
+))
+def test_required_settings(settings, missing_setting):
+    delattr(settings, missing_setting)
+
+    with pytest.raises(HelmetImproperlyConfiguredException) as e:
+        validate_patron('1234567', '1234')
+
+    assert missing_setting in str(e)
+
+
+@mock.patch(
+    'identities.helmet_requests.requests.post',
+    side_effect=(DummyTokenResponse(), DummyResponse(status_code=204)),
+)
+def test_validate_patron(post):
+    is_valid = validate_patron('1234567', '1234')
+    assert is_valid
+
+    post.assert_has_calls([
+        mock.call(
+            'http://api.test.com/v1/token',
+            auth=('test_helmet_api_username', 'test_helmet_api_password'),
+        ),
+        mock.call(
+            'http://api.test.com/v1/patrons/validate',
+            headers={'Authorization': 'Bearer test_access_token'},
+            json={'barcode': '1234567', 'pin': '1234'}
+        )
+    ])
+
+
+@mock.patch(
+    'identities.helmet_requests.requests.post',
+    side_effect=(DummyTokenResponse(), DummyValidatePatronFailedResponse()),
+)
+def test_validate_patron_invalid_credentials(post):
+    is_valid = validate_patron('1234567', '1234')
+    assert not is_valid
+
+
+@mock.patch(
+    'identities.helmet_requests.requests.post',
+    side_effect=RequestException,
+)
+def test_connection_error(post):
+    with pytest.raises(HelmetConnectionException):
+        validate_patron('1234567', '1234')
+
+
+@mock.patch(
+    'identities.helmet_requests.requests.post',
+    side_effect=(DummyTokenResponse(), DummyValidatePatronFailedResponse()),
+)
+@mock.patch('identities.helmet_requests.cache.set')
+def test_validate_patron_token_cache_default_timeout(cache_set, post):
+    validate_patron('1234567', '1234')
+    cache_set.assert_called_with('HELMET_API_ACCESS_TOKEN', 'test_access_token', 300)
+
+
+@mock.patch(
+    'identities.helmet_requests.requests.post',
+    side_effect=(DummyTokenResponse(expires_in=160), DummyValidatePatronFailedResponse()),
+)
+@mock.patch('identities.helmet_requests.cache.set')
+def test_validate_patron_token_cache_timeout_from_token(cache_set, post):
+    validate_patron('1234567', '1234')
+    cache_set.assert_called_with('HELMET_API_ACCESS_TOKEN', 'test_access_token', 100)
+
+
+@mock.patch(
+    'identities.helmet_requests.requests.post',
+    side_effect=(DummyTokenResponse(), DummyValidatePatronFailedResponse()) * 2,
+)
+@mock.patch('identities.helmet_requests.cache.set')
+def test_validate_patron_token_cache_timeout_in_settings(cache_set, post, settings):
+    settings.CACHES['default']['TIMEOUT'] = 100000
+    validate_patron('1234567', '1234')
+    cache_set.assert_called_with('HELMET_API_ACCESS_TOKEN', 'test_access_token', 3540)
+
+    settings.CACHES['default']['TIMEOUT'] = 100
+    validate_patron('1234567', '1234')
+    cache_set.assert_called_with('HELMET_API_ACCESS_TOKEN', 'test_access_token', 100)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -4,3 +4,4 @@ pytest
 pytest-cov
 pytest-django
 httpretty
+factory_boy

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -5,3 +5,4 @@ pytest-cov
 pytest-django
 httpretty
 factory_boy
+freezegun

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ coverage==4.5.1
 factory-boy==2.10.0
 faker==0.8.12
 flake8==3.5.0
+freezegun==0.3.10
 httpretty==0.8.14
 isort==4.3.4
 mccabe==0.6.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,8 @@
 #
 attrs==17.4.0
 coverage==4.5.1
+factory-boy==2.10.0
+faker==0.8.12
 flake8==3.5.0
 httpretty==0.8.14
 isort==4.3.4
@@ -15,4 +17,6 @@ pyflakes==1.6.0
 pytest==3.4.0
 pytest-cov==2.5.1
 pytest-django==3.1.2
+python-dateutil==2.7.0
 six==1.11.0
+text-unidecode==1.2

--- a/tunnistamo/api_common.py
+++ b/tunnistamo/api_common.py
@@ -53,7 +53,7 @@ def make_scope_domain_map(scopes):
 
 class TokenAuth:
     def __init__(self, scopes):
-        assert isinstance(scopes, (list, tuple))
+        assert isinstance(scopes, (list, tuple, set))
         self.scopes = scopes
         self.scope_domains = make_scope_domain_map(scopes)
 
@@ -140,8 +140,7 @@ class DeviceGeneratedJWTAuthentication(BaseAuthentication):
         if interface_secret != interface_device.secret_key:
             raise AuthenticationFailed("Incorrect interface device secret in X-Interface-Device-Secret HTTP header")
 
-        auth = TokenAuth()
-        auth.scopes = set(interface_device.scopes.split())
+        auth = TokenAuth(set(interface_device.scopes.split()))
 
         return (device.user, auth)
 

--- a/tunnistamo/api_common.py
+++ b/tunnistamo/api_common.py
@@ -86,7 +86,7 @@ class OidcTokenAuthentication(BaseAuthentication):
 
 
 class DeviceGeneratedJWTAuthentication(BaseAuthentication):
-    def authenticate(self, request):
+    def authenticate(self, request):  # noqa  (too complex)
         token_value = extract_access_token(request)
         if not token_value:
             return None

--- a/tunnistamo/api_common.py
+++ b/tunnistamo/api_common.py
@@ -1,21 +1,20 @@
 import datetime
-import logging
 import json
-import pytz
+import logging
 
-from django.contrib.auth import get_user_model
+import pytz
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
-from jwcrypto import jwk, jwe, jwt
+from jwcrypto import jwe, jwk, jwt
 from oidc_provider.lib.errors import BearerTokenError
 from oidc_provider.lib.utils.oauth2 import extract_access_token
 from oidc_provider.models import Token
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
-from rest_framework.permissions import BasePermission, SAFE_METHODS
+from rest_framework.permissions import SAFE_METHODS, BasePermission
 
-from devices.models import UserDevice, InterfaceDevice
-
+from devices.models import InterfaceDevice, UserDevice
 
 User = get_user_model()
 logger = logging.getLogger(__name__)

--- a/tunnistamo/factories.py
+++ b/tunnistamo/factories.py
@@ -1,0 +1,27 @@
+import factory
+from django.contrib.auth import get_user_model
+from oidc_provider.tests.app.utils import create_fake_client, create_fake_token
+
+User = get_user_model()
+
+
+def access_token_factory(**kwargs):
+    access_token = kwargs.pop('access_token', 'test_access_token')
+    token = create_fake_token(
+        user=kwargs.get('user', UserFactory()),
+        client=kwargs.get('client', create_fake_client('token')),
+        scopes=kwargs.get('scopes', []),
+    )
+    token.access_token = access_token
+    token.save()
+    return token
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    username = factory.Faker('user_name')
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    email = factory.Faker('email')
+
+    class Meta:
+        model = User

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -225,7 +225,8 @@ OAUTH2_PROVIDER = {
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
-    )
+    ),
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 CSRF_COOKIE_NAME = 'sso-csrftoken'
 SESSION_COOKIE_NAME = 'sso-sessionid'

--- a/users/management/commands/social_auth_migrate.py
+++ b/users/management/commands/social_auth_migrate.py
@@ -1,6 +1,5 @@
 from allauth.socialaccount.models import SocialAccount, SocialApp
 from django.core.management.base import BaseCommand
-from django.db import IntegrityError
 from social_django.models import UserSocialAuth
 
 

--- a/users/views.py
+++ b/users/views.py
@@ -15,7 +15,7 @@ from .models import LoginMethod, OidcClientOptions
 class LoginView(TemplateView):
     template_name = "login.html"
 
-    def get(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):  # noqa  (too complex)
         next_url = request.GET.get('next')
         app = None
         oidc_client = None


### PR DESCRIPTION
* Implemented tests for `devices` and `identities` apps

* Changed `UserDeviceViewSet` to use `ScopePermission`

* A couple of bug fixes

* Fixed Travis build for Python 3.6 (nightly still broken)