### PR TITLE
Define scope_-methods in the CustomInfoTextStandardScopeClaims itself

### DIFF
--- a/oidc_apis/scopes.py
+++ b/oidc_apis/scopes.py
@@ -66,6 +66,18 @@ class CustomInfoTextStandardScopeClaims(StandardScopeClaims):
         _('Access to your address. Includes country, locality, street and other information.'),
     )
 
+    def scope_profile(self):
+        return super().scope_profile()
+
+    def scope_email(self):
+        return super().scope_email()
+
+    def scope_phone(self):
+        return super().scope_phone()
+
+    def scope_address(self):
+        return super().scope_address()
+
 
 class CombinedScopeClaims(ScopeClaims):
     combined_scope_claims = [


### PR DESCRIPTION
django-oidc-provider will search scopes from the claims classes using
__dir__ which doesn't include inherited methods or attributes.

By defining the methods in the class itself the scopes are found.