### PR TITLE
Add "consent_given" field to service API endpoint

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -26,3 +26,4 @@ Pillow
 django-crequest
 django-ipware
 geoip2
+django-filter

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ django-bootstrap3==10.0.1
 django-compressor==2.2
 django-cors-headers==2.2.0
 django-crequest==2018.5.11
+django-filter==2.0.0
 django-helusers==0.4.2
 django-ipware==2.1.0
 django-multiselectfield==0.1.8

--- a/services/api.py
+++ b/services/api.py
@@ -1,3 +1,7 @@
+from django.db.models import Exists, OuterRef
+from django.db.models.functions import Greatest
+from oauth2_provider.models import AccessToken
+from oidc_provider.models import UserConsent
 from rest_framework import serializers, viewsets
 
 from services.models import Service
@@ -14,8 +18,29 @@ class ServiceSerializer(TranslatableSerializer):
         model = Service
         fields = ('id', 'name', 'url', 'description', 'image')
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+
+        if hasattr(instance, 'consent_given'):
+            data['consent_given'] = instance.consent_given
+
+        return data
+
 
 class ServiceViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ServiceSerializer
     queryset = Service.objects.all()
     pagination_class = DefaultPagination
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        user = self.request.user
+
+        if user.is_authenticated:
+            user_consents = UserConsent.objects.filter(client__service=OuterRef('pk'), user=user)
+            user_access_tokens = AccessToken.objects.filter(application__service=OuterRef('pk'), user=user)
+            queryset = queryset.annotate(
+                consent_given=Greatest(Exists(user_consents), Exists(user_access_tokens))
+            )
+
+        return queryset

--- a/services/api.py
+++ b/services/api.py
@@ -1,5 +1,7 @@
 from django.db.models import Exists, OuterRef
 from django.db.models.functions import Greatest
+from django_filters import rest_framework as filters
+from django_filters.widgets import BooleanWidget
 from oauth2_provider.models import AccessToken
 from oidc_provider.models import UserConsent
 from rest_framework import serializers, viewsets
@@ -27,10 +29,25 @@ class ServiceSerializer(TranslatableSerializer):
         return data
 
 
+class ServiceFilter(filters.FilterSet):
+    consent_given = filters.Filter(method='filter_consent_given', widget=BooleanWidget())
+
+    class Meta:
+        model = Service
+        fields = ('consent_given',)
+
+    def filter_consent_given(self, queryset, name, value):
+        if 'consent_given' in queryset.query.annotations.keys():
+            queryset = queryset.filter(consent_given=value)
+
+        return queryset
+
+
 class ServiceViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = ServiceSerializer
     queryset = Service.objects.all()
     pagination_class = DefaultPagination
+    filterset_class = ServiceFilter
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/services/factories.py
+++ b/services/factories.py
@@ -15,7 +15,7 @@ class ServiceFactory(factory.django.DjangoModelFactory):
     client = factory.LazyAttribute(lambda o: OIDCClientFactory() if o.target == 'client' else None)
 
     class Params:
-        target = 'client'
+        target = None
 
     class Meta:
         model = Service

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -3,6 +3,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 
 from services.factories import ServiceFactory
+from users.factories import OAuth2AccessTokenFactory, UserConsentFactory, UserFactory
 
 LIST_URL = reverse('v1:service-list')
 
@@ -19,6 +20,19 @@ def auto_mark_django_db(db):
 @pytest.fixture
 def api_client():
     return APIClient()
+
+
+@pytest.fixture
+def user():
+    return UserFactory()
+
+
+@pytest.fixture
+def user_api_client(user):
+    api_client = APIClient()
+    api_client.force_authenticate(user=user)
+    api_client.user = user
+    return api_client
 
 
 @pytest.fixture
@@ -50,3 +64,31 @@ def test_get(api_client, service, endpoint):
     assert service_data['name'] == {'fi': service.name}
     assert service_data['description'] == {'fi': service.description}
     assert service_data['url'] == {'fi': service.url}
+
+
+def test_service_consent_given_field(user_api_client):
+    user = user_api_client.user
+    other_user = UserFactory()
+
+    not_connected_client_service = ServiceFactory(target='client')
+    not_connected_application_service = ServiceFactory(target='application')
+    other_user_client_service = ServiceFactory(target='client')
+    UserConsentFactory(user=other_user, client=other_user_client_service.client)
+    other_user_application_service = ServiceFactory(target='application')
+    OAuth2AccessTokenFactory(user=other_user, application=other_user_application_service.application)
+
+    own_client_service = ServiceFactory(target='client')
+    UserConsentFactory(user=user, client=own_client_service.client)
+    own_application_service = ServiceFactory(target='application')
+    OAuth2AccessTokenFactory(user=user, application=own_application_service.application)
+
+    for service in (not_connected_client_service, not_connected_application_service, other_user_client_service,
+                    other_user_application_service):
+        response = user_api_client.get(get_detail_url(service))
+        assert response.status_code == 200
+        assert response.data['consent_given'] is False
+
+    for service in (own_client_service, own_application_service):
+        response = user_api_client.get(get_detail_url(service))
+        assert response.status_code == 200
+        assert response.data['consent_given'] is True

--- a/services/tests/test_api.py
+++ b/services/tests/test_api.py
@@ -23,7 +23,7 @@ def api_client():
 
 @pytest.fixture
 def service():
-    return ServiceFactory()
+    return ServiceFactory(target='client')
 
 
 @pytest.mark.parametrize('endpoint', ('list', 'detail'))

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -55,6 +55,7 @@ INSTALLED_APPS = (
     'helsinki_theme',
     'bootstrap3',
     'crequest',
+    'django_filters',
 
     'helusers',
 
@@ -235,6 +236,9 @@ OAUTH2_PROVIDER = {
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/tunnistamo/utils.py
+++ b/tunnistamo/utils.py
@@ -119,3 +119,7 @@ class TranslatableSerializer(serializers.Serializer):
                 translation = instance._get_translated_model(lang_code, auto_create=True)
                 setattr(translation, field, value)
         instance.save_translations()
+
+
+def assert_objects_in_response(response, objects):
+    assert {r['id'] for r in response.data['results']} == {o.id for o in objects}

--- a/users/factories.py
+++ b/users/factories.py
@@ -65,7 +65,7 @@ def fake_dict():
 
 class UserLoginEntryFactory(factory.django.DjangoModelFactory):
     user = factory.SubFactory(UserFactory)
-    service = factory.SubFactory('services.factories.ServiceFactory')
+    service = factory.SubFactory('services.factories.ServiceFactory', target='client')
     timestamp = factory.LazyFunction(now)
     ip_address = factory.Faker('ipv4')
     geo_location = factory.LazyFunction(fake_dict)

--- a/users/factories.py
+++ b/users/factories.py
@@ -4,6 +4,7 @@ import factory
 from django.contrib.auth import get_user_model
 from django.utils.timezone import now
 from faker import Faker
+from oauth2_provider.models import AccessToken
 from oidc_provider.models import Client, UserConsent
 from oidc_provider.tests.app.utils import create_fake_client, create_fake_token
 
@@ -83,3 +84,14 @@ class UserConsentFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = UserConsent
+
+
+class OAuth2AccessTokenFactory(factory.django.DjangoModelFactory):
+    user = factory.SubFactory(UserFactory)
+    application = factory.SubFactory(ApplicationFactory)
+    expires = factory.LazyAttribute(lambda o: now() + timedelta(days=1))
+    scope = 'read write'
+    token = factory.Faker('uuid4')
+
+    class Meta:
+        model = AccessToken

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -164,4 +164,4 @@ def user_api_client(user):
 
 @pytest.fixture
 def service():
-    return ServiceFactory()
+    return ServiceFactory(target='client')


### PR DESCRIPTION
When an authenticated user fetches service data, there is a boolean field
`consent_given` which indicates whether the user has been connected to the
service. The information for this comes from UserConsent model if the service
is connected to a Client (OIDC Provider), or from AccessToken model if the
service is connected to an Application (OAuth2 Provider).

It is also possible to filter service list by consent_given value i.e. 
`/v1/service/?consent_given=<true or false>`

Closes #61 