### PR TITLE
Allow both client and application to be empty for a Service

### DIFF
--- a/services/models.py
+++ b/services/models.py
@@ -34,8 +34,6 @@ class Service(TranslatableModel):
         return self.name
 
     def clean(self):
-        if not (self.application or self.client):
-            raise ValidationError(_('Either application or client required.'))
         if self.application and self.client:
             raise ValidationError(_('Cannot set both application and client.'))
 

--- a/services/tests/test_models.py
+++ b/services/tests/test_models.py
@@ -18,12 +18,6 @@ def test_create_with_client():
     ServiceFactory(target='client')
 
 
-def test_create_without_application_or_client():
-    with pytest.raises(ValidationError) as e:
-        ServiceFactory(target='this target creates neither')
-    assert 'Either application or client required.' in str(e)
-
-
 def test_create_with_both_application_and_client():
     with pytest.raises(ValidationError) as e:
         ServiceFactory(application=ApplicationFactory(), client=OIDCClientFactory())


### PR DESCRIPTION
We need to use Service model to store service descriptions without any actual functionality ie. consents, login history. Also having mandatory client or application wasn't that useful anyway.