### PR TITLE
Add also scopes required by APIs to UserConsent objects

### DIFF
--- a/oidc_apis/factories.py
+++ b/oidc_apis/factories.py
@@ -1,0 +1,37 @@
+import factory
+
+from users.factories import OIDCClientFactory
+
+from .models import Api, ApiDomain, ApiScope
+
+
+def create_oidc_client_for_api(api):
+    domain_identifier = api.domain.identifier.rstrip('/')
+    return OIDCClientFactory(client_id='{}/{}'.format(domain_identifier, api.name))
+
+
+class ApiDomainFactory(factory.django.DjangoModelFactory):
+    identifier = factory.Faker('url')
+
+    class Meta:
+        model = ApiDomain
+
+
+class ApiFactory(factory.django.DjangoModelFactory):
+    domain = factory.SubFactory(ApiDomainFactory)
+    name = factory.Faker('word')
+    oidc_client = factory.LazyAttribute(create_oidc_client_for_api)
+
+    class Meta:
+        model = Api
+
+
+class ApiScopeFactory(factory.django.DjangoModelFactory):
+    api = factory.SubFactory(ApiFactory)
+    specifier = ''
+    identifier = factory.LazyAttribute(ApiScope._generate_identifier)
+    name = factory.Faker('word')
+    description = factory.Faker('sentence')
+
+    class Meta:
+        model = ApiScope

--- a/oidc_apis/scopes.py
+++ b/oidc_apis/scopes.py
@@ -2,7 +2,6 @@ from django.utils.translation import ugettext_lazy as _
 from oidc_provider.lib.claims import ScopeClaims, StandardScopeClaims
 
 from .models import ApiScope
-from .utils import combine_uniquely
 
 
 class ApiScopeClaims(ScopeClaims):
@@ -111,7 +110,7 @@ class CombinedScopeClaims(ScopeClaims):
 
     @classmethod
     def get_scopes_info(cls, scopes=[]):
-        extended_scopes = cls._extend_scope(scopes)
+        extended_scopes = ApiScope.extend_scope(scopes)
         scopes_info_map = {}
         for claim_cls in cls.combined_scope_claims:
             for info in claim_cls.get_scopes_info(extended_scopes):
@@ -121,18 +120,6 @@ class CombinedScopeClaims(ScopeClaims):
             for scope in extended_scopes
             if scope in scopes_info_map
         ]
-
-    @classmethod
-    def _extend_scope(cls, scopes):
-        required_scopes = cls._get_all_required_scopes_by_api_scopes(scopes)
-        extended_scopes = combine_uniquely(scopes, sorted(required_scopes))
-        return extended_scopes
-
-    @classmethod
-    def _get_all_required_scopes_by_api_scopes(cls, scopes):
-        api_scopes = ApiScope.objects.by_identifiers(scopes)
-        apis = {x.api for x in api_scopes}
-        return set(sum((list(api.required_scopes) for api in apis), []))
 
     def __init__(self, token, *args, **kwargs):
         self._token = token

--- a/users/tests/test_tunnistamo_authorize_view.py
+++ b/users/tests/test_tunnistamo_authorize_view.py
@@ -1,6 +1,8 @@
 import pytest
 from django.urls import reverse
+from oidc_provider.models import UserConsent
 
+from oidc_apis.factories import ApiFactory, ApiScopeFactory
 from users.factories import OIDCClientFactory, UserFactory
 from users.views import TunnistamoOidcAuthorizeView
 
@@ -36,3 +38,50 @@ def test_tunnistamo_authorize_view_language(client):
     data['lang'] = 'bogus'
     response = client.get(url, data)
     assert 'Sähköposti' in response.content.decode('utf-8')
+
+
+@pytest.mark.django_db
+def test_api_scopes_are_shown_in_and_returned_from_consent_screen(client):
+    oidc_client = OIDCClientFactory(require_consent=True)
+    user = UserFactory()
+    client.force_login(user)
+
+    api = ApiFactory(required_scopes=['github_username'])
+    api_scope = ApiScopeFactory(api=api)
+
+    response = client.get(reverse('authorize'), {
+        'client_id': oidc_client.client_id,
+        'redirect_uri': oidc_client.redirect_uris[0],
+        'scope': api_scope.identifier,
+        'response_type': 'code',
+    })
+    assert response.status_code == 200
+
+    content = response.content.decode('utf-8')
+    expected_scope = '{} github_username'.format(api_scope.identifier)
+    assert '<input name="scope" type="hidden" value="{}" />'.format(expected_scope) in content
+    assert api_scope.name in content
+    assert api_scope.description in content
+
+
+@pytest.mark.parametrize('api_scope_in_request', (False, True))
+@pytest.mark.django_db
+def test_api_scopes_are_added_to_user_consent_after_authorization(client, api_scope_in_request):
+    oidc_client = OIDCClientFactory(require_consent=True)
+    user = UserFactory()
+    client.force_login(user)
+
+    api = ApiFactory(required_scopes=['github_username'])
+    api_scope = ApiScopeFactory(api=api)
+
+    response = client.post(reverse('authorize'), {
+        'client_id': oidc_client.client_id,
+        'redirect_uri': oidc_client.redirect_uris[0],
+        'scope': '{} github_username'.format(api_scope.identifier) if api_scope_in_request else api_scope.identifier,
+        'response_type': 'code',
+        'allow': True,
+    })
+    assert response.status_code == 302
+
+    user_consent = UserConsent.objects.get(user=user, client=oidc_client)
+    assert 'github_username' in user_consent.scope


### PR DESCRIPTION
Previously if there was an API, which required some scope "X", that scope X
was displayed in the consent screen, but it was not added to the UserConsent
object generated as result of the authorization. Therefore it was not
possible to figure out later all the scopes a user has given consent to.

This implementation involves manipulating GET and POST params before the
authorization view, so it is a bit hacky solution, but probably still the
cleanest possible as there is no way to customize Django OIDC Provider's
authorization process.

Closes #71