### PR TITLE
Add API list endpoint for OIDC scopes

### DIFF
--- a/scopes/api.py
+++ b/scopes/api.py
@@ -1,0 +1,90 @@
+from django.conf import settings
+from django.utils import translation
+from django.utils.translation.trans_real import translation as trans_real_translation
+from rest_framework import serializers
+from rest_framework.schemas import AutoSchema
+from rest_framework.views import APIView
+
+from oidc_apis.models import ApiScope
+from oidc_apis.scopes import CombinedScopeClaims
+from tunnistamo.pagination import DefaultPagination
+from tunnistamo.utils import TranslatableSerializer
+
+ENGLISH_LANGUAGE_CODE = 'en'
+LANGUAGE_CODES = [l[0] for l in settings.LANGUAGES]
+assert ENGLISH_LANGUAGE_CODE in LANGUAGE_CODES
+
+
+class ApiScopeSerializer(TranslatableSerializer):
+    id = serializers.CharField(source='identifier')
+
+    class Meta:
+        model = ApiScope
+        fields = ('id', 'name', 'description')
+
+
+class AutoSchemaWithPaginationParams(AutoSchema):
+    def get_pagination_fields(self, path, method):
+        return DefaultPagination().get_schema_fields(method)
+
+
+class ScopeListView(APIView):
+    """
+    List scopes related to OIDC authentication.
+    """
+    schema = AutoSchemaWithPaginationParams()
+
+    def get(self, request, format=None):
+        # Return OIDC scopes first and API scopes second, and both of those are also ordered alphabetically by ID.
+        # Because why not.
+        oidc_scopes = self._create_oidc_scopes_data()
+        api_scopes = ApiScopeSerializer(ApiScope.objects.order_by('identifier'), many=True).data
+        all_scopes = oidc_scopes + api_scopes
+
+        self.paginator.paginate_queryset(all_scopes, self.request, view=self)
+        response = self.paginator.get_paginated_response(all_scopes)
+
+        return response
+
+    @property
+    def paginator(self):
+        if not hasattr(self, '_paginator'):
+            self._paginator = DefaultPagination()
+        return self._paginator
+
+    @classmethod
+    def _create_oidc_scopes_data(cls):
+        if hasattr(cls, '_oidc_scopes_data'):
+            return cls._oidc_scopes_data
+
+        ret = []
+
+        for claim_cls in CombinedScopeClaims.combined_scope_claims:
+            for name in dir(claim_cls):
+                if name.startswith('info_'):
+                    scope_identifier = name.split('info_')[1]
+                    scope_data = getattr(claim_cls, name)
+                    ret.append({
+                        'id': scope_identifier,
+                        'name': cls._create_translated_field_from_string(scope_data[0]),
+                        'description': cls._create_translated_field_from_string(scope_data[1]),
+                    })
+
+        ret.sort(key=lambda x: x['id'])
+        cls._oidc_scopes_data = ret
+
+        return ret
+
+    @classmethod
+    def _create_translated_field_from_string(cls, field):
+        with translation.override(ENGLISH_LANGUAGE_CODE):
+            value_in_english = str(field)
+
+        ret = {ENGLISH_LANGUAGE_CODE: value_in_english}
+
+        for language in [lc for lc in LANGUAGE_CODES if lc != ENGLISH_LANGUAGE_CODE]:
+            translated_value = trans_real_translation(language)._catalog.get(value_in_english)
+            if translated_value:
+                ret[language] = translated_value
+
+        return ret

--- a/scopes/tests/test_api.py
+++ b/scopes/tests/test_api.py
@@ -1,0 +1,72 @@
+import pytest
+from parler.utils.context import switch_language
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from oidc_apis.factories import ApiDomainFactory, ApiFactory, ApiScopeFactory
+
+LIST_URL = reverse('v1:scope-list')
+
+EXPECTED_OIDC_SCOPES = [
+    'ad_groups',
+    'address',
+    'devices',
+    'email',
+    'github_username',
+    'identities',
+    'login_entries',
+    'phone',
+    'profile',
+]
+
+
+@pytest.fixture(autouse=True)
+def auto_mark_django_db(db):
+    pass
+
+
+@pytest.fixture(autouse=True)
+def force_english(settings):
+    settings.LANGUAGE_CODE = 'en'
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+def test_get_oidc_scopes_list(api_client):
+    response = api_client.get(LIST_URL)
+    assert response.status_code == 200
+
+    results = response.data['results']
+    assert len(results) == len(EXPECTED_OIDC_SCOPES)
+    assert [s['id'] for s in results] == EXPECTED_OIDC_SCOPES
+    email_scope_data = next(s for s in results if s['id'] == 'email')
+    assert email_scope_data.keys() == {'id', 'name', 'description'}
+    assert email_scope_data['name'] == {'fi': 'Sähköposti', 'sv': 'E-postadress', 'en': 'Email'}
+
+
+def test_get_also_api_scopes_list(api_client):
+    foo_scope = ApiScopeFactory(api=ApiFactory(domain=ApiDomainFactory(identifier='https://foo.com')))
+    with switch_language(foo_scope, 'fi'):
+        foo_scope.name = 'nimi'
+        foo_scope.description = 'kuvaus'
+        foo_scope.save()
+
+    bar_scope = ApiScopeFactory(api=ApiFactory(domain=ApiDomainFactory(identifier='https://bar.com')))
+
+    response = api_client.get(LIST_URL)
+    assert response.status_code == 200
+
+    results = response.data['results']
+    assert len(results) == len(EXPECTED_OIDC_SCOPES) + 2
+
+    foo_scope_data = results[len(EXPECTED_OIDC_SCOPES) + 1]
+    bar_scope_data = results[len(EXPECTED_OIDC_SCOPES)]
+
+    assert foo_scope_data['id'] == foo_scope.identifier
+    assert bar_scope_data['id'] == bar_scope.identifier
+
+    assert foo_scope_data['name'] == {'en': foo_scope.name, 'fi': 'nimi'}
+    assert foo_scope_data['description'] == {'en': foo_scope.description, 'fi': 'kuvaus'}

--- a/tunnistamo/urls.py
+++ b/tunnistamo/urls.py
@@ -14,6 +14,7 @@ from rest_framework.schemas import SchemaGenerator
 from devices.api import UserDeviceViewSet
 from identities.api import UserIdentityViewSet
 from oidc_apis.views import get_api_tokens_view
+from scopes.api import ScopeListView
 from services.api import ServiceViewSet
 from tunnistamo import social_auth_urls
 from users.api import UserConsentViewSet, UserLoginEntryViewSet
@@ -51,7 +52,8 @@ router.register('user_login_entry', UserLoginEntryViewSet)
 router.register('service', ServiceViewSet)
 router.register('user_consent', UserConsentViewSet)
 
-v1_api_path = path('v1/', include((router.urls, 'v1')))
+v1_scope_path = path('scope/', ScopeListView.as_view(), name='scope-list')
+v1_api_path = path('v1/', include((router.urls + [v1_scope_path], 'v1')))
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION
The endpoint includes all the scopes: the default ones coming from Django
OIDC provider, the custom ones defined in CombinedScopeClaims class, and
also the scopes for the APIs.

Refs https://github.com/City-of-Helsinki/omahelsinki/issues/136