### PR TITLE
Add a .well-known URL to the root of the instance

### DIFF
--- a/tunnistamo/urls.py
+++ b/tunnistamo/urls.py
@@ -10,6 +10,7 @@ from django.views.defaults import permission_denied
 from rest_framework.documentation import include_docs_urls
 from rest_framework.routers import SimpleRouter
 from rest_framework.schemas import SchemaGenerator
+from oidc_provider.views import ProviderInfoView as OIDCProviderInfoView
 
 from devices.api import UserDeviceViewSet
 from identities.api import UserIdentityViewSet
@@ -66,6 +67,7 @@ urlpatterns = [
     path('oauth2/', include(oauth2_provider.urls, namespace='oauth2_provider')),
     re_path(r'^openid/authorize/?$', TunnistamoOidcAuthorizeView.as_view(), name='authorize'),
     path('openid/', include(oidc_provider.urls, namespace='oidc_provider')),
+    re_path(r'^\.well-known/openid-configuration/?$', OIDCProviderInfoView.as_view(), name='root-provider-info'),
     re_path(r'^user/(?P<username>[\w.@+-]+)/?$', UserView.as_view()),
     path('user/', UserView.as_view()),
     path('jwt-token/', GetJWTView.as_view()),

--- a/tunnistamo/urls.py
+++ b/tunnistamo/urls.py
@@ -7,10 +7,10 @@ from django.http import HttpResponse
 from django.urls import include, path, re_path
 from django.utils import translation
 from django.views.defaults import permission_denied
+from oidc_provider.views import ProviderInfoView as OIDCProviderInfoView
 from rest_framework.documentation import include_docs_urls
 from rest_framework.routers import SimpleRouter
 from rest_framework.schemas import SchemaGenerator
-from oidc_provider.views import ProviderInfoView as OIDCProviderInfoView
 
 from devices.api import UserDeviceViewSet
 from identities.api import UserIdentityViewSet


### PR DESCRIPTION
The well-known URI should be placed in the root of the instance for discovery mechanism to work properly. This PR adds another route to the `oidc_provider` view `ProviderInfoView`. The old URL still works normally for backwards compatibility.