### PR TITLE
Do not create multiple social provider associations for logged in users.

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -348,6 +348,9 @@ SOCIAL_AUTH_PIPELINE = (
     # Create a user account if we haven't found one yet.
     'social_core.pipeline.user.create_user',
 
+    # Verify that the user doesn't have existing social account with another provider.
+    'users.pipeline.check_existing_social_associations',
+
     # Create the record that associated the social account with this user.
     'social_core.pipeline.social_auth.associate_user',
 

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -140,3 +140,13 @@ def update_ad_groups(details, backend, user=None, *args, **kwargs):
         return
 
     user.update_ad_groups(details['ad_groups'])
+
+
+def check_existing_social_associations(backend, strategy, user=None, social=None, *args, **kwargs):
+    if user and not social:
+        social_set = user.social_auth.all()
+        providers = [a.provider for a in social_set]
+        if providers and backend.name not in providers:
+            strategy.request.other_logins = LoginMethod.objects.filter(provider_id__in=providers)
+            error_view = AuthenticationErrorView(request=strategy.request)
+            return error_view.get(strategy.request)


### PR DESCRIPTION
If a logged in user is already associated with a social auth provider this fix prevents creating a new association and shows the same error message than for those existing users who are not currently logged in and try to log in with another social provider than originally.

If a user already has multiple social auth provider associations this fix doesn't prevent the user from logging in with any of them (but prevents associating more).