### PR TITLE
Use non-binary psycopg2

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,8 @@
 #
 #   prequ update
 #
+--no-binary psycopg2
+
 argparse==1.4.0           # via unittest2
 atomicwrites==1.1.5       # via pytest
 attrs==18.1.0             # via pytest

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ django-helusers
 django-allauth
 django-bootstrap3
 psycopg2
-psycopg2-binary
+--no-binary psycopg2
 raven
 PyJWT
 cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 #
 #   prequ update
 #
+--no-binary psycopg2
+
 asn1crypto==0.24.0        # via cryptography
 certifi==2018.4.16        # via requests
 cffi==1.11.5              # via cryptography
@@ -46,7 +48,6 @@ pillow==5.1.0
 pkgconfig==1.3.1          # via xmlsec
 polib==1.1.0              # via django-translation-checker
 psycopg2==2.7.4
-psycopg2-binary==2.7.4
 pyasn1==0.4.5             # via rsa
 pycparser==2.18           # via cffi
 pycryptodomex==3.6.1      # via pyjwkest


### PR DESCRIPTION
The binary version of psycopg2 causes problems in some environments.