### PR TITLE
Implement new logout screen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_install:
 
 install: 'pip install codecov -r requirements.txt -r requirements-dev.txt'
 
+before_script: 'python manage.py compilemessages'
+
 script:
   # Run the tests
   - flake8

--- a/auth_backends/facebook.py
+++ b/auth_backends/facebook.py
@@ -1,0 +1,21 @@
+from django.utils.translation import gettext as _
+from social_core.backends.facebook import FacebookOAuth2
+
+
+class Facebook(FacebookOAuth2):
+    persistent_session_warning = _(
+        "Please note that you are still logged in to Facebook"
+    )
+    persistent_session_suggestion = _(
+        "Go back to Facebook where you can log yourself out "
+        "in the usual manner:"
+    )
+    persistent_session_link = _(
+        "Go to Facebook"
+    )
+    persistent_session_final_warning = _(
+        "If access to this device is shared by other users, "
+        "the next user will be able to access your Facebook account "
+        "unless you explicitly log out from Facebook."
+    )
+    user_facing_url = 'https://www.facebook.com'

--- a/auth_backends/facebook.py
+++ b/auth_backends/facebook.py
@@ -1,21 +1,12 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext, pgettext
 from social_core.backends.facebook import FacebookOAuth2
 
 
 class Facebook(FacebookOAuth2):
-    persistent_session_warning = _(
-        "Please note that you are still logged in to Facebook"
-    )
-    persistent_session_suggestion = _(
-        "Go back to Facebook where you can log yourself out "
-        "in the usual manner:"
-    )
-    persistent_session_link = _(
-        "Go to Facebook"
-    )
-    persistent_session_final_warning = _(
-        "If access to this device is shared by other users, "
-        "the next user will be able to access your Facebook account "
-        "unless you explicitly log out from Facebook."
-    )
     user_facing_url = 'https://www.facebook.com'
+    name_baseform = gettext('Facebook')
+    name_access = pgettext('access to []', 'Facebook')
+    name_genetive = pgettext('genetive form', 'Facebook')
+    name_logged_in_to = pgettext('logged in to []', 'Facebook')
+    name_logout_from = pgettext('log out from []', 'Facebook')
+    name_goto = pgettext('go to []', 'Facebook')

--- a/auth_backends/github.py
+++ b/auth_backends/github.py
@@ -1,0 +1,21 @@
+from django.utils.translation import gettext as _
+from social_core.backends.github import GithubOAuth2
+
+
+class Github(GithubOAuth2):
+    persistent_session_warning = _(
+        "Please note that you are still logged in to GitHub"
+    )
+    persistent_session_suggestion = _(
+        "Go back to GitHub where you can log yourself out "
+        "in the usual manner:"
+    )
+    persistent_session_link = _(
+        "Go to GitHub"
+    )
+    persistent_session_final_warning = _(
+        "If access to this device is shared by other users, "
+        "the next user will be able to access your GitHub account "
+        "unless you explicitly log out from GitHub."
+    )
+    user_facing_url = 'https://github.com'

--- a/auth_backends/github.py
+++ b/auth_backends/github.py
@@ -1,21 +1,12 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext, pgettext
 from social_core.backends.github import GithubOAuth2
 
 
 class Github(GithubOAuth2):
-    persistent_session_warning = _(
-        "Please note that you are still logged in to GitHub"
-    )
-    persistent_session_suggestion = _(
-        "Go back to GitHub where you can log yourself out "
-        "in the usual manner:"
-    )
-    persistent_session_link = _(
-        "Go to GitHub"
-    )
-    persistent_session_final_warning = _(
-        "If access to this device is shared by other users, "
-        "the next user will be able to access your GitHub account "
-        "unless you explicitly log out from GitHub."
-    )
     user_facing_url = 'https://github.com'
+    name_baseform = gettext('GitHub')
+    name_access = pgettext('access to []', 'GitHub')
+    name_genetive = pgettext('genetive form', 'GitHub')
+    name_logged_in_to = pgettext('logged in to []', 'GitHub')
+    name_logout_from = pgettext('log out from []', 'GitHub')
+    name_goto = pgettext('go to []', 'GitHub')

--- a/auth_backends/google.py
+++ b/auth_backends/google.py
@@ -1,5 +1,23 @@
+from django.utils.translation import gettext as _
 from social_core.backends.google import GoogleOAuth2
 
 
 class GoogleOAuth2CustomName(GoogleOAuth2):
     name = 'google'
+
+    persistent_session_warning = _(
+        "Please note that you are still logged in to Google's services"
+    )
+    persistent_session_suggestion = _(
+        "Go back to Google to log yourself out "
+        "in the usual manner:"
+    )
+    persistent_session_link = _(
+        "Go to Google"
+    )
+    persistent_session_final_warning = _(
+        "If access to this device is shared by other users, "
+        "the next user will be able to access your Google account "
+        "unless you explicitly log out from Google."
+    )
+    user_facing_url = 'https://myaccount.google.com/'

--- a/auth_backends/google.py
+++ b/auth_backends/google.py
@@ -1,23 +1,13 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext, pgettext
 from social_core.backends.google import GoogleOAuth2
 
 
 class GoogleOAuth2CustomName(GoogleOAuth2):
     name = 'google'
-
-    persistent_session_warning = _(
-        "Please note that you are still logged in to Google's services"
-    )
-    persistent_session_suggestion = _(
-        "Go back to Google to log yourself out "
-        "in the usual manner:"
-    )
-    persistent_session_link = _(
-        "Go to Google"
-    )
-    persistent_session_final_warning = _(
-        "If access to this device is shared by other users, "
-        "the next user will be able to access your Google account "
-        "unless you explicitly log out from Google."
-    )
     user_facing_url = 'https://myaccount.google.com/'
+    name_baseform = gettext('Google')
+    name_access = pgettext('access to []', 'Google')
+    name_genetive = pgettext('genetive form', 'Google')
+    name_logged_in_to = pgettext('logged in to []', 'Google')
+    name_logout_from = pgettext('log out from []', 'Google')
+    name_goto = pgettext('go to []', 'Google')

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -2,98 +2,128 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Timo Tuominen <dev@hel.fi>, 2019
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Tunnistamo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-17 07:26+0000\n"
-"PO-Revision-Date: 2019-08-12 13:50+0300\n"
+"POT-Creation-Date: 2019-10-31 14:16+0000\n"
+"PO-Revision-Date: 2019-11-01 13:41+0200\n"
 "Last-Translator: Timo Tuominen <dev@hel.fi>, 2019\n"
-"Language-Team: Finnish (https://www.transifex.com/city-of-helsinki-1/teams/98217/fi/)\n"
+"Language-Team: Finnish (https://www.transifex.com/city-of-helsinki-1/"
+"teams/98217/fi/)\n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fi\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: adfs_provider/models.py:18
-msgid "Primary SID"
-msgstr ""
+#
+#: auth_backends/facebook.py:7
+msgid "Please note that you are still logged in to Facebook"
+msgstr "Huomaa, että olet edelleen kirjautuneena Facebook-tilillesi,"
 
-#: adfs_provider/models.py:19
-msgid "Department name"
-msgstr ""
+#: auth_backends/facebook.py:10
+msgid "Go back to Facebook where you can log yourself out in the usual manner:"
+msgstr "Siirry Facebookiin ja kirjaudu ulos Facebook-käyttäjätililtäsi sieltä käsin."
 
-#: adfs_provider/models.py:20 oidc_apis/scopes.py:81
-msgid "Email"
-msgstr "Sähköpostiosoite"
+#: auth_backends/facebook.py:14
+msgid "Go to Facebook"
+msgstr "Siirry Facebookiin"
 
-#: adfs_provider/models.py:21
-msgid "Username"
-msgstr "Käyttäjätunnus"
+#: auth_backends/facebook.py:17
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your Facebook account unless you explicitly log out from "
+"Facebook."
+msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos Facebookista, laitteen seuraava käyttäjä pääsee nimissäsi Facebookiin!"
 
-#: adfs_provider/models.py:22 oidc_apis/models.py:25 oidc_apis/scopes.py:67
-msgid "AD Groups"
-msgstr "AD-ryhmät"
+#
+#: auth_backends/github.py:7
+msgid "Please note that you are still logged in to GitHub"
+msgstr "Huomaa, että olet vielä kirjautuneena GitHub-tiliisi,"
 
-#: adfs_provider/models.py:23
-msgid "First name"
-msgstr "Etunimi"
+#: auth_backends/github.py:10
+msgid "Go back to GitHub where you can log yourself out in the usual manner:"
+msgstr "Siirry takaisin GitHubiin ja kirjaudu sieltä ulos GitHubin omalla uloskirjautumistoiminnolla:"
 
-#: adfs_provider/models.py:24
-msgid "Last name"
-msgstr "Sukunimi"
+#: auth_backends/github.py:14
+msgid "Go to GitHub"
+msgstr "Siirry GitHubiin"
 
-#: devices/models.py:17 identities/models.py:11 users/models.py:105
+#: auth_backends/github.py:17
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your GitHub account unless you explicitly log out from GitHub."
+msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos GitHubista, laitteen seuraava käyttäjä pääsee nimissäsi GitHubiin!"
+
+#: auth_backends/google.py:9
+msgid "Please note that you are still logged in to Google's services"
+msgstr "Huomaa, että olet vielä kirjautuneena Google-tilillesi,"
+
+#: auth_backends/google.py:12
+msgid "Go back to Google to log yourself out in the usual manner:"
+msgstr "Siirry takaisin Google-tiliisi ja kirjaudu siltä ulos Googlen omalla uloskirjautumistoiminnolla:"
+
+#: auth_backends/google.py:16
+msgid "Go to Google"
+msgstr "Siirry Googleen"
+
+#: auth_backends/google.py:19
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your Google account unless you explicitly log out from Google."
+msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos Google-tililtäsi, laitteen seuraava käyttäjä pääsee käyttämään nimissäsi Google-tiliäsi!"
+
+#: devices/models.py:18 identities/models.py:11 users/models.py:115
 msgid "user"
 msgstr "käyttäjä"
 
-#: devices/models.py:18
+#: devices/models.py:19
 msgid "public key"
 msgstr "julkinen avain"
 
-#: devices/models.py:19 devices/models.py:37
+#: devices/models.py:20 devices/models.py:38
 msgid "secret key"
 msgstr "salainen avain"
 
-#: devices/models.py:20
+#: devices/models.py:21
 msgid "app version"
 msgstr "sovelluksen versio"
 
-#: devices/models.py:21
+#: devices/models.py:22
 msgid "OS"
 msgstr "Käyttöjärjestelmä"
 
-#: devices/models.py:22
+#: devices/models.py:23
 msgid "OS version"
 msgstr "Käyttöjärjestelmän versio"
 
-#: devices/models.py:23
+#: devices/models.py:24
 msgid "device model"
 msgstr "laitteen malli"
 
-#: devices/models.py:24
+#: devices/models.py:25
 msgid "last used at"
 msgstr "viimeksi käytetty"
 
-#: devices/models.py:28
+#: devices/models.py:29
 msgid "user device"
 msgstr "käyttäjän laite"
 
-#: devices/models.py:29
+#: devices/models.py:30
 msgid "user devices"
 msgstr "käyttäjien laitteet"
 
-#: devices/models.py:38
+#: devices/models.py:39
 msgid "allowed OAuth scopes"
 msgstr ""
 
-#: identities/models.py:12 services/models.py:29 users/models.py:107
+#: identities/models.py:12 services/models.py:29 users/models.py:117
 msgid "service"
 msgstr "palvelu"
 
@@ -137,6 +167,10 @@ msgstr "Osoite"
 msgid "GitHub username"
 msgstr "GitHub käyttäjätunnus"
 
+#: oidc_apis/models.py:25 oidc_apis/scopes.py:67
+msgid "AD Groups"
+msgstr "AD-ryhmät"
+
 #: oidc_apis/models.py:33
 msgid "API domain identifier, e.g. https://api.hel.fi/auth"
 msgstr ""
@@ -159,8 +193,8 @@ msgstr ""
 
 #: oidc_apis/models.py:58
 msgid ""
-"Select the scopes that this API needs information from. Information from the"
-" selected scopes will be included to the API Tokens."
+"Select the scopes that this API needs information from. Information from the "
+"selected scopes will be included to the API Tokens."
 msgstr ""
 
 #: oidc_apis/models.py:65
@@ -197,8 +231,8 @@ msgstr ""
 #: oidc_apis/models.py:141
 msgid ""
 "If there is a need for multiple scopes per API, this can specify what kind "
-"of scope this is about, e.g. \"readonly\".  For general API scope just leave"
-" this empty."
+"of scope this is about, e.g. \"readonly\".  For general API scope just leave "
+"this empty."
 msgstr ""
 
 #: oidc_apis/models.py:149
@@ -207,8 +241,7 @@ msgstr ""
 
 #: oidc_apis/models.py:150
 msgid ""
-"Select client applications which are allowed to get access to this API "
-"scope."
+"Select client applications which are allowed to get access to this API scope."
 msgstr ""
 
 #: oidc_apis/models.py:157 oidc_apis/models.py:190
@@ -277,10 +310,13 @@ msgstr "Perustiedot"
 
 #: oidc_apis/scopes.py:78
 msgid ""
-"Access to your basic information. Includes names and possibly a user "
-"picture."
+"Access to your basic information. Includes names and possibly a user picture."
 msgstr ""
 "Lupa lukea perustiedot, jotka sisältävät nimet ja mahdollisen profiilikuvan."
+
+#: oidc_apis/scopes.py:81
+msgid "Email"
+msgstr "Sähköpostiosoite"
 
 #: oidc_apis/scopes.py:82
 msgid "Access to your email address."
@@ -312,8 +348,8 @@ msgstr "Kentät joita ei käännetä"
 
 #: services/api.py:37
 msgid ""
-"Include only services that have or don't have a consent given by the current"
-" user. Accepts boolean values \"true\" and \"false\"."
+"Include only services that have or don't have a consent given by the current "
+"user. Accepts boolean values \"true\" and \"false\"."
 msgstr ""
 
 #: services/models.py:13
@@ -354,31 +390,39 @@ msgstr ""
 msgid "Users"
 msgstr "Käyttäjät"
 
-#: users/models.py:76
+#: users/models.py:73
+msgid "Post Logout Redirect URIs"
+msgstr ""
+
+#: users/models.py:74
+msgid "Enter each URI on a new line."
+msgstr ""
+
+#: users/models.py:82
 msgid "OIDC Client"
 msgstr ""
 
-#: users/models.py:82 users/models.py:83
+#: users/models.py:88 users/models.py:89
 msgid "OIDC Client Options"
 msgstr ""
 
-#: users/models.py:109
+#: users/models.py:119
 msgid "timestamp"
 msgstr "aikaleima"
 
-#: users/models.py:110
+#: users/models.py:120
 msgid "IP address"
 msgstr "IP-osoite"
 
-#: users/models.py:111
+#: users/models.py:121
 msgid "geo location"
 msgstr "sijaintitiedot"
 
-#: users/models.py:116
+#: users/models.py:126
 msgid "user login entry"
 msgstr "kirjautumismerkintä"
 
-#: users/models.py:117
+#: users/models.py:127
 msgid "user login entries"
 msgstr "kirjautumismerkinnät"
 
@@ -402,3 +446,57 @@ msgstr "Älä anna lupaa"
 #: users/templates/oidc_provider/authorize.html:21
 msgid "Allow"
 msgstr "Anna lupa"
+
+#: users/templates/registration/logged_out.html:4
+msgid "You have been logged out"
+msgstr "Sinut on kirjattu ulos"
+
+#: users/templates/registration/logged_out.html:7
+msgid "You have been logged out of City of Helsinki services."
+msgstr "Sinut on kirjattu ulos Helsingin kaupungin palveluista."
+
+#: users/templates/registration/logged_out.html:11
+msgid ""
+"whose credentials you originally used to log in to City of Helsinki services."
+msgstr "jolla alun perin kirjauduit Helsingin kaupungin palveluihin."
+
+#: users/templates/registration/logged_out.html:23
+msgid "Return"
+msgstr "Palaa"
+
+#
+#: yletunnus/backends.py:53
+msgid "Please note that you are still logged in to Yle Tunnus"
+msgstr "Huomaa, että olet vielä kirjautuneena Yle Tunnus -tilillesi,"
+
+#: yletunnus/backends.py:56
+msgid ""
+"Go back to Yle Tunnus where you can log yourself out in the usual manner:"
+msgstr "Siirry takaisin Yle Tunnukseen ja kirjaudu sieltä ulos Yle Tunnuksen omalla uloskirjautumistoiminnolla:"
+
+#: yletunnus/backends.py:60
+msgid "Go to Yle Tunnus"
+msgstr "Siirry Yle Tunnukseen"
+
+#: yletunnus/backends.py:63
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your Yle account unless you explicitly log out from Yle "
+"Tunnus."
+msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos Yle Tunnus -tililtäsi, laitteen seuraava käyttäjä pääsee käyttämään Yle Tunnusta nimissäsi!"
+
+#~ msgid ""
+#~ "If desired, you can go back to Facebook to log out using Facebook's own "
+#~ "log out feature:"
+#~ msgstr ""
+#~ "Jos haluat, voit mennä takaisin Facebookiin kirjautumaan sieltä ulos "
+#~ "Facebookin omalla uloskirjautumistoiminnolla:"
+
+#~ msgid "Username"
+#~ msgstr "Käyttäjätunnus"
+
+#~ msgid "First name"
+#~ msgstr "Etunimi"
+
+#~ msgid "Last name"
+#~ msgstr "Sukunimi"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -6,13 +6,12 @@
 # Translators:
 # Timo Tuominen <dev@hel.fi>, 2019
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Tunnistamo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-31 14:16+0000\n"
-"PO-Revision-Date: 2019-11-01 13:41+0200\n"
+"POT-Creation-Date: 2019-11-14 15:14+0000\n"
+"PO-Revision-Date: 2019-11-14 17:13+0200\n"
 "Last-Translator: Timo Tuominen <dev@hel.fi>, 2019\n"
 "Language-Team: Finnish (https://www.transifex.com/city-of-helsinki-1/"
 "teams/98217/fi/)\n"
@@ -22,62 +21,92 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#
 #: auth_backends/facebook.py:7
-msgid "Please note that you are still logged in to Facebook"
-msgstr "Huomaa, että olet edelleen kirjautuneena Facebook-tilillesi,"
+msgid "Facebook"
+msgstr "Facebook"
+
+#: auth_backends/facebook.py:8
+msgctxt "access to []"
+msgid "Facebook"
+msgstr "Facebookiin"
+
+#: auth_backends/facebook.py:9
+msgctxt "genetive form"
+msgid "Facebook"
+msgstr "Facebookin"
 
 #: auth_backends/facebook.py:10
-msgid "Go back to Facebook where you can log yourself out in the usual manner:"
-msgstr "Siirry Facebookiin ja kirjaudu ulos Facebook-käyttäjätililtäsi sieltä käsin."
+msgctxt "logged in to []"
+msgid "Facebook"
+msgstr "Facebookiin"
 
-#: auth_backends/facebook.py:14
-msgid "Go to Facebook"
-msgstr "Siirry Facebookiin"
+#: auth_backends/facebook.py:11
+msgctxt "log out from []"
+msgid "Facebook"
+msgstr "Facebookista"
 
-#: auth_backends/facebook.py:17
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your Facebook account unless you explicitly log out from "
-"Facebook."
-msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos Facebookista, laitteen seuraava käyttäjä pääsee nimissäsi Facebookiin!"
+#: auth_backends/facebook.py:12
+msgctxt "go to []"
+msgid "Facebook"
+msgstr "Facebookiin"
 
-#
 #: auth_backends/github.py:7
-msgid "Please note that you are still logged in to GitHub"
-msgstr "Huomaa, että olet vielä kirjautuneena GitHub-tiliisi,"
+msgid "GitHub"
+msgstr "GitHub"
+
+#: auth_backends/github.py:8
+msgctxt "access to []"
+msgid "GitHub"
+msgstr "GitHubiin"
+
+#: auth_backends/github.py:9
+msgctxt "genetive form"
+msgid "GitHub"
+msgstr "GitHubin"
 
 #: auth_backends/github.py:10
-msgid "Go back to GitHub where you can log yourself out in the usual manner:"
-msgstr "Siirry takaisin GitHubiin ja kirjaudu sieltä ulos GitHubin omalla uloskirjautumistoiminnolla:"
+msgctxt "logged in to []"
+msgid "GitHub"
+msgstr "GitHubiin"
 
-#: auth_backends/github.py:14
-msgid "Go to GitHub"
-msgstr "Siirry GitHubiin"
+#: auth_backends/github.py:11
+msgctxt "log out from []"
+msgid "GitHub"
+msgstr "GitHubista"
 
-#: auth_backends/github.py:17
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your GitHub account unless you explicitly log out from GitHub."
-msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos GitHubista, laitteen seuraava käyttäjä pääsee nimissäsi GitHubiin!"
+#: auth_backends/github.py:12
+msgctxt "go to []"
+msgid "GitHub"
+msgstr "GitHubiin"
+
+#: auth_backends/google.py:8
+msgid "Google"
+msgstr "Google"
 
 #: auth_backends/google.py:9
-msgid "Please note that you are still logged in to Google's services"
-msgstr "Huomaa, että olet vielä kirjautuneena Google-tilillesi,"
+msgctxt "access to []"
+msgid "Google"
+msgstr "Googleen"
+
+#: auth_backends/google.py:10
+msgctxt "genetive form"
+msgid "Google"
+msgstr "Googlen"
+
+#: auth_backends/google.py:11
+msgctxt "logged in to []"
+msgid "Google"
+msgstr "Google-tilillesi"
 
 #: auth_backends/google.py:12
-msgid "Go back to Google to log yourself out in the usual manner:"
-msgstr "Siirry takaisin Google-tiliisi ja kirjaudu siltä ulos Googlen omalla uloskirjautumistoiminnolla:"
+msgctxt "log out from []"
+msgid "Google"
+msgstr "Googlesta"
 
-#: auth_backends/google.py:16
-msgid "Go to Google"
-msgstr "Siirry Googleen"
-
-#: auth_backends/google.py:19
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your Google account unless you explicitly log out from Google."
-msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos Google-tililtäsi, laitteen seuraava käyttäjä pääsee käyttämään nimissäsi Google-tiliäsi!"
+#: auth_backends/google.py:13
+msgctxt "go to []"
+msgid "Google"
+msgstr "Googleen"
 
 #: devices/models.py:18 identities/models.py:11 users/models.py:115
 msgid "user"
@@ -447,56 +476,72 @@ msgstr "Älä anna lupaa"
 msgid "Allow"
 msgstr "Anna lupa"
 
-#: users/templates/registration/logged_out.html:4
-msgid "You have been logged out"
-msgstr "Sinut on kirjattu ulos"
-
-#: users/templates/registration/logged_out.html:7
+#: users/templates/registration/logged_out.html:5
 msgid "You have been logged out of City of Helsinki services."
 msgstr "Sinut on kirjattu ulos Helsingin kaupungin palveluista."
 
-#: users/templates/registration/logged_out.html:11
+#: users/templates/registration/logged_out.html:10
+#, python-format
 msgid ""
-"whose credentials you originally used to log in to City of Helsinki services."
-msgstr "jolla alun perin kirjauduit Helsingin kaupungin palveluihin."
+"Please note that you are still logged in to %(name_logged_in)s, whose "
+"credentials you originally used to log in to City of Helsinki services."
+msgstr ""
+"Huomaa, että olet edelleen kirjautuneena %(name_logged_in)s, jolla alun "
+"perin kirjauduit Helsingin kaupungin palveluihin."
 
-#: users/templates/registration/logged_out.html:23
+#: users/templates/registration/logged_out.html:17
+#, python-format
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your %(name_access)s account unless you explicitly log out "
+"from %(name_logout)s."
+msgstr ""
+"Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos "
+"%(name_logout)s, laitteen seuraava käyttäjä pääsee nimissäsi %(name_access)s!"
+
+#: users/templates/registration/logged_out.html:26
+#, python-format
+msgid ""
+"Go back to %(name_goto)s to log yourself out using %(name_genetive)s own "
+"logout feature."
+msgstr ""
+"Siirry %(name_goto)s ja kirjaudu siellä ulos %(name_genetive)s omalla "
+"uloskirjautumistoiminnolla."
+
+#: users/templates/registration/logged_out.html:31
+#, python-format
+msgid "Go to %(name_goto)s"
+msgstr "Siirry %(name_goto)s"
+
+#: users/templates/registration/logged_out.html:41
 msgid "Return"
 msgstr "Palaa"
 
-#
-#: yletunnus/backends.py:53
-msgid "Please note that you are still logged in to Yle Tunnus"
-msgstr "Huomaa, että olet vielä kirjautuneena Yle Tunnus -tilillesi,"
+#: yletunnus/backends.py:54
+msgid "Yle Tunnus"
+msgstr "Yle Tunnus"
+
+#: yletunnus/backends.py:55
+msgctxt "access to []"
+msgid "Yle Tunnus"
+msgstr "Ylen palveluihin"
 
 #: yletunnus/backends.py:56
-msgid ""
-"Go back to Yle Tunnus where you can log yourself out in the usual manner:"
-msgstr "Siirry takaisin Yle Tunnukseen ja kirjaudu sieltä ulos Yle Tunnuksen omalla uloskirjautumistoiminnolla:"
+msgctxt "genetive form"
+msgid "Yle Tunnus"
+msgstr "Yle Tunnuksen"
 
-#: yletunnus/backends.py:60
-msgid "Go to Yle Tunnus"
-msgstr "Siirry Yle Tunnukseen"
+#: yletunnus/backends.py:57
+msgctxt "logged in to []"
+msgid "Yle Tunnus"
+msgstr "Yle Tunnukseesi"
 
-#: yletunnus/backends.py:63
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your Yle account unless you explicitly log out from Yle "
-"Tunnus."
-msgstr "Jos tämä laite on yhteiskäytössä, etkä kirjaudu omatoimisesti ulos Yle Tunnus -tililtäsi, laitteen seuraava käyttäjä pääsee käyttämään Yle Tunnusta nimissäsi!"
+#: yletunnus/backends.py:58
+msgctxt "log out from []"
+msgid "Yle Tunnus"
+msgstr "Yle Tunnuksesta"
 
-#~ msgid ""
-#~ "If desired, you can go back to Facebook to log out using Facebook's own "
-#~ "log out feature:"
-#~ msgstr ""
-#~ "Jos haluat, voit mennä takaisin Facebookiin kirjautumaan sieltä ulos "
-#~ "Facebookin omalla uloskirjautumistoiminnolla:"
-
-#~ msgid "Username"
-#~ msgstr "Käyttäjätunnus"
-
-#~ msgid "First name"
-#~ msgstr "Etunimi"
-
-#~ msgid "Last name"
-#~ msgstr "Sukunimi"
+#: yletunnus/backends.py:59
+msgctxt "go to []"
+msgid "Yle Tunnus"
+msgstr "Yle Tunnukseen"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -2,98 +2,126 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-# 
+#
 # Translators:
 # Henrik Andersson <dev@hel.fi>, 2019
-# 
+#
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Tunnistamo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-17 07:26+0000\n"
+"POT-Creation-Date: 2019-10-31 14:16+0000\n"
 "PO-Revision-Date: 2019-08-12 13:51+0300\n"
 "Last-Translator: Henrik Andersson <dev@hel.fi>, 2019\n"
-"Language-Team: Swedish (https://www.transifex.com/city-of-helsinki-1/teams/98217/sv/)\n"
+"Language-Team: Swedish (https://www.transifex.com/city-of-helsinki-1/"
+"teams/98217/sv/)\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: adfs_provider/models.py:18
-msgid "Primary SID"
+#: auth_backends/facebook.py:7
+msgid "Please note that you are still logged in to Facebook"
 msgstr ""
 
-#: adfs_provider/models.py:19
-msgid "Department name"
+#: auth_backends/facebook.py:10
+msgid "Go back to Facebook where you can log yourself out in the usual manner:"
 msgstr ""
 
-#: adfs_provider/models.py:20 oidc_apis/scopes.py:81
-msgid "Email"
-msgstr "E-postadress"
+#: auth_backends/facebook.py:14
+msgid "Go to Facebook"
+msgstr ""
 
-#: adfs_provider/models.py:21
-msgid "Username"
-msgstr "Användarnamn"
+#: auth_backends/facebook.py:17
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your Facebook account unless you explicitly log out from "
+"Facebook."
+msgstr ""
 
-#: adfs_provider/models.py:22 oidc_apis/models.py:25 oidc_apis/scopes.py:67
-msgid "AD Groups"
-msgstr "AD-grupper"
+#: auth_backends/github.py:7
+msgid "Please note that you are still logged in to GitHub"
+msgstr ""
 
-#: adfs_provider/models.py:23
-msgid "First name"
-msgstr "Förnamn"
+#: auth_backends/github.py:10
+msgid "Go back to GitHub where you can log yourself out in the usual manner:"
+msgstr ""
 
-#: adfs_provider/models.py:24
-msgid "Last name"
-msgstr "Efternamn"
+#: auth_backends/github.py:14
+msgid "Go to GitHub"
+msgstr ""
 
-#: devices/models.py:17 identities/models.py:11 users/models.py:105
+#: auth_backends/github.py:17
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your GitHub account unless you explicitly log out from GitHub."
+msgstr ""
+
+#: auth_backends/google.py:9
+msgid "Please note that you are still logged in to Google's services"
+msgstr ""
+
+#: auth_backends/google.py:12
+msgid "Go back to Google to log yourself out in the usual manner:"
+msgstr ""
+
+#: auth_backends/google.py:16
+msgid "Go to Google"
+msgstr ""
+
+#: auth_backends/google.py:19
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your Google account unless you explicitly log out from Google."
+msgstr ""
+
+#: devices/models.py:18 identities/models.py:11 users/models.py:115
 msgid "user"
 msgstr "användare"
 
-#: devices/models.py:18
+#: devices/models.py:19
 msgid "public key"
 msgstr "öppen nyckel"
 
-#: devices/models.py:19 devices/models.py:37
+#: devices/models.py:20 devices/models.py:38
 msgid "secret key"
 msgstr "hemlig nyckel"
 
-#: devices/models.py:20
+#: devices/models.py:21
 msgid "app version"
 msgstr "Version av applikationen"
 
-#: devices/models.py:21
+#: devices/models.py:22
 msgid "OS"
 msgstr "Operativsystem"
 
-#: devices/models.py:22
+#: devices/models.py:23
 msgid "OS version"
 msgstr "Version av operativsystemet"
 
-#: devices/models.py:23
+#: devices/models.py:24
 msgid "device model"
 msgstr "Enhetsmodell"
 
-#: devices/models.py:24
+#: devices/models.py:25
 msgid "last used at"
 msgstr "användes senast"
 
-#: devices/models.py:28
+#: devices/models.py:29
 msgid "user device"
 msgstr "användarens enhet"
 
-#: devices/models.py:29
+#: devices/models.py:30
 msgid "user devices"
 msgstr "användarens enheter"
 
-#: devices/models.py:38
+#: devices/models.py:39
 msgid "allowed OAuth scopes"
 msgstr ""
 
-#: identities/models.py:12 services/models.py:29 users/models.py:107
+#: identities/models.py:12 services/models.py:29 users/models.py:117
 msgid "service"
 msgstr "tjänst"
 
@@ -137,6 +165,10 @@ msgstr "Adress"
 msgid "GitHub username"
 msgstr "användarnamn på GitHub"
 
+#: oidc_apis/models.py:25 oidc_apis/scopes.py:67
+msgid "AD Groups"
+msgstr "AD-grupper"
+
 #: oidc_apis/models.py:33
 msgid "API domain identifier, e.g. https://api.hel.fi/auth"
 msgstr ""
@@ -159,8 +191,8 @@ msgstr ""
 
 #: oidc_apis/models.py:58
 msgid ""
-"Select the scopes that this API needs information from. Information from the"
-" selected scopes will be included to the API Tokens."
+"Select the scopes that this API needs information from. Information from the "
+"selected scopes will be included to the API Tokens."
 msgstr ""
 
 #: oidc_apis/models.py:65
@@ -197,8 +229,8 @@ msgstr ""
 #: oidc_apis/models.py:141
 msgid ""
 "If there is a need for multiple scopes per API, this can specify what kind "
-"of scope this is about, e.g. \"readonly\".  For general API scope just leave"
-" this empty."
+"of scope this is about, e.g. \"readonly\".  For general API scope just leave "
+"this empty."
 msgstr ""
 
 #: oidc_apis/models.py:149
@@ -207,8 +239,7 @@ msgstr ""
 
 #: oidc_apis/models.py:150
 msgid ""
-"Select client applications which are allowed to get access to this API "
-"scope."
+"Select client applications which are allowed to get access to this API scope."
 msgstr ""
 
 #: oidc_apis/models.py:157 oidc_apis/models.py:190
@@ -277,11 +308,14 @@ msgstr "Grundläggande profil"
 
 #: oidc_apis/scopes.py:78
 msgid ""
-"Access to your basic information. Includes names and possibly a user "
-"picture."
+"Access to your basic information. Includes names and possibly a user picture."
 msgstr ""
 "Åtkomst till din grundläggande information. Innehåller namn och eventuellt "
 "en användarbild."
+
+#: oidc_apis/scopes.py:81
+msgid "Email"
+msgstr "E-postadress"
 
 #: oidc_apis/scopes.py:82
 msgid "Access to your email address."
@@ -312,8 +346,8 @@ msgstr "Fält som inte kan översättas"
 
 #: services/api.py:37
 msgid ""
-"Include only services that have or don't have a consent given by the current"
-" user. Accepts boolean values \"true\" and \"false\"."
+"Include only services that have or don't have a consent given by the current "
+"user. Accepts boolean values \"true\" and \"false\"."
 msgstr ""
 
 #: services/models.py:13
@@ -354,31 +388,39 @@ msgstr ""
 msgid "Users"
 msgstr "Användare"
 
-#: users/models.py:76
+#: users/models.py:73
+msgid "Post Logout Redirect URIs"
+msgstr ""
+
+#: users/models.py:74
+msgid "Enter each URI on a new line."
+msgstr ""
+
+#: users/models.py:82
 msgid "OIDC Client"
 msgstr ""
 
-#: users/models.py:82 users/models.py:83
+#: users/models.py:88 users/models.py:89
 msgid "OIDC Client Options"
 msgstr ""
 
-#: users/models.py:109
+#: users/models.py:119
 msgid "timestamp"
 msgstr "tidsstämpel"
 
-#: users/models.py:110
+#: users/models.py:120
 msgid "IP address"
 msgstr "IP-adress"
 
-#: users/models.py:111
+#: users/models.py:121
 msgid "geo location"
 msgstr "geolokaliseringsdata"
 
-#: users/models.py:116
+#: users/models.py:126
 msgid "user login entry"
 msgstr "inloggningspost"
 
-#: users/models.py:117
+#: users/models.py:127
 msgid "user login entries"
 msgstr "inloggningposter"
 
@@ -402,3 +444,49 @@ msgstr "Avvisa"
 #: users/templates/oidc_provider/authorize.html:21
 msgid "Allow"
 msgstr "Godkänn"
+
+#: users/templates/registration/logged_out.html:4
+msgid "You have been logged out"
+msgstr ""
+
+#: users/templates/registration/logged_out.html:7
+msgid "You have been logged out of City of Helsinki services."
+msgstr ""
+
+#: users/templates/registration/logged_out.html:11
+msgid ""
+"whose credentials you originally used to log in to City of Helsinki services."
+msgstr ""
+
+#: users/templates/registration/logged_out.html:23
+msgid "Return"
+msgstr ""
+
+#: yletunnus/backends.py:53
+msgid "Please note that you are still logged in to Yle Tunnus"
+msgstr ""
+
+#: yletunnus/backends.py:56
+msgid ""
+"Go back to Yle Tunnus where you can log yourself out in the usual manner:"
+msgstr ""
+
+#: yletunnus/backends.py:60
+msgid "Go to Yle Tunnus"
+msgstr ""
+
+#: yletunnus/backends.py:63
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your Yle account unless you explicitly log out from Yle "
+"Tunnus."
+msgstr ""
+
+#~ msgid "Username"
+#~ msgstr "Användarnamn"
+
+#~ msgid "First name"
+#~ msgstr "Förnamn"
+
+#~ msgid "Last name"
+#~ msgstr "Efternamn"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Tunnistamo\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-31 14:16+0000\n"
+"POT-Creation-Date: 2019-11-14 15:14+0000\n"
 "PO-Revision-Date: 2019-08-12 13:51+0300\n"
 "Last-Translator: Henrik Andersson <dev@hel.fi>, 2019\n"
 "Language-Team: Swedish (https://www.transifex.com/city-of-helsinki-1/"
@@ -23,58 +23,90 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: auth_backends/facebook.py:7
-msgid "Please note that you are still logged in to Facebook"
+msgid "Facebook"
+msgstr ""
+
+#: auth_backends/facebook.py:8
+msgctxt "access to []"
+msgid "Facebook"
+msgstr ""
+
+#: auth_backends/facebook.py:9
+msgctxt "genetive form"
+msgid "Facebook"
 msgstr ""
 
 #: auth_backends/facebook.py:10
-msgid "Go back to Facebook where you can log yourself out in the usual manner:"
+msgctxt "logged in to []"
+msgid "Facebook"
 msgstr ""
 
-#: auth_backends/facebook.py:14
-msgid "Go to Facebook"
+#: auth_backends/facebook.py:11
+msgctxt "log out from []"
+msgid "Facebook"
 msgstr ""
 
-#: auth_backends/facebook.py:17
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your Facebook account unless you explicitly log out from "
-"Facebook."
+#: auth_backends/facebook.py:12
+msgctxt "go to []"
+msgid "Facebook"
 msgstr ""
 
 #: auth_backends/github.py:7
-msgid "Please note that you are still logged in to GitHub"
+msgid "GitHub"
+msgstr ""
+
+#: auth_backends/github.py:8
+msgctxt "access to []"
+msgid "GitHub"
+msgstr ""
+
+#: auth_backends/github.py:9
+msgctxt "genetive form"
+msgid "GitHub"
 msgstr ""
 
 #: auth_backends/github.py:10
-msgid "Go back to GitHub where you can log yourself out in the usual manner:"
+msgctxt "logged in to []"
+msgid "GitHub"
 msgstr ""
 
-#: auth_backends/github.py:14
-msgid "Go to GitHub"
+#: auth_backends/github.py:11
+msgctxt "log out from []"
+msgid "GitHub"
 msgstr ""
 
-#: auth_backends/github.py:17
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your GitHub account unless you explicitly log out from GitHub."
+#: auth_backends/github.py:12
+msgctxt "go to []"
+msgid "GitHub"
+msgstr ""
+
+#: auth_backends/google.py:8
+msgid "Google"
 msgstr ""
 
 #: auth_backends/google.py:9
-msgid "Please note that you are still logged in to Google's services"
+msgctxt "access to []"
+msgid "Google"
+msgstr ""
+
+#: auth_backends/google.py:10
+msgctxt "genetive form"
+msgid "Google"
+msgstr ""
+
+#: auth_backends/google.py:11
+msgctxt "logged in to []"
+msgid "Google"
 msgstr ""
 
 #: auth_backends/google.py:12
-msgid "Go back to Google to log yourself out in the usual manner:"
+msgctxt "log out from []"
+msgid "Google"
 msgstr ""
 
-#: auth_backends/google.py:16
-msgid "Go to Google"
-msgstr ""
-
-#: auth_backends/google.py:19
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your Google account unless you explicitly log out from Google."
+#: auth_backends/google.py:13
+msgctxt "go to []"
+msgid "Google"
 msgstr ""
 
 #: devices/models.py:18 identities/models.py:11 users/models.py:115
@@ -445,41 +477,68 @@ msgstr "Avvisa"
 msgid "Allow"
 msgstr "Godkänn"
 
-#: users/templates/registration/logged_out.html:4
-msgid "You have been logged out"
-msgstr ""
-
-#: users/templates/registration/logged_out.html:7
+#: users/templates/registration/logged_out.html:5
 msgid "You have been logged out of City of Helsinki services."
 msgstr ""
 
-#: users/templates/registration/logged_out.html:11
+#: users/templates/registration/logged_out.html:10
+#, python-format
 msgid ""
-"whose credentials you originally used to log in to City of Helsinki services."
+"Please note that you are still logged in to %(name_logged_in)s, whose "
+"credentials you originally used to log in to City of Helsinki services."
 msgstr ""
 
-#: users/templates/registration/logged_out.html:23
+#: users/templates/registration/logged_out.html:17
+#, python-format
+msgid ""
+"If access to this device is shared by other users, the next user will be "
+"able to access your %(name_access)s account unless you explicitly log out "
+"from %(name_logout)s."
+msgstr ""
+
+#: users/templates/registration/logged_out.html:26
+#, python-format
+msgid ""
+"Go back to %(name_goto)s to log yourself out using %(name_genetive)s own "
+"logout feature."
+msgstr ""
+
+#: users/templates/registration/logged_out.html:31
+#, python-format
+msgid "Go to %(name_goto)s"
+msgstr ""
+
+#: users/templates/registration/logged_out.html:41
 msgid "Return"
 msgstr ""
 
-#: yletunnus/backends.py:53
-msgid "Please note that you are still logged in to Yle Tunnus"
+#: yletunnus/backends.py:54
+msgid "Yle Tunnus"
+msgstr ""
+
+#: yletunnus/backends.py:55
+msgctxt "access to []"
+msgid "Yle Tunnus"
 msgstr ""
 
 #: yletunnus/backends.py:56
-msgid ""
-"Go back to Yle Tunnus where you can log yourself out in the usual manner:"
+msgctxt "genetive form"
+msgid "Yle Tunnus"
 msgstr ""
 
-#: yletunnus/backends.py:60
-msgid "Go to Yle Tunnus"
+#: yletunnus/backends.py:57
+msgctxt "logged in to []"
+msgid "Yle Tunnus"
 msgstr ""
 
-#: yletunnus/backends.py:63
-msgid ""
-"If access to this device is shared by other users, the next user will be "
-"able to access your Yle account unless you explicitly log out from Yle "
-"Tunnus."
+#: yletunnus/backends.py:58
+msgctxt "log out from []"
+msgid "Yle Tunnus"
+msgstr ""
+
+#: yletunnus/backends.py:59
+msgctxt "go to []"
+msgid "Yle Tunnus"
 msgstr ""
 
 #~ msgid "Username"

--- a/scopes/tests/test_api.py
+++ b/scopes/tests/test_api.py
@@ -44,7 +44,7 @@ def test_get_oidc_scopes_list(api_client):
     assert [s['id'] for s in results] == EXPECTED_OIDC_SCOPES
     email_scope_data = next(s for s in results if s['id'] == 'email')
     assert email_scope_data.keys() == {'id', 'name', 'description'}
-    assert email_scope_data['name'] == {'fi': 'Sähköposti', 'sv': 'E-postadress', 'en': 'Email'}
+    assert email_scope_data['name'] == {'fi': 'Sähköpostiosoite', 'sv': 'E-postadress', 'en': 'Email'}
 
 
 def test_get_also_api_scopes_list(api_client):

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -78,7 +78,6 @@ X_FRAME_OPTIONS = 'DENY'
 # Application definition
 
 INSTALLED_APPS = (
-    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.sites',
     'django.contrib.contenttypes',
@@ -91,6 +90,8 @@ INSTALLED_APPS = (
     'oauth2_provider',
     'users',
     'oidc_provider',
+
+    'django.contrib.admin',
 
     'allauth',
     'allauth.account',
@@ -144,12 +145,12 @@ AUTHENTICATION_BACKENDS = (
     'auth_backends.eduhelfi.EduHelFiAzure',
     'auth_backends.espoo.EspooAzure',
     'auth_backends.adfs.helsinki.HelsinkiADFS',
+    'auth_backends.facebook.Facebook',
+    'auth_backends.github.Github',
     'auth_backends.google.GoogleOAuth2CustomName',
     'auth_backends.adfs.helsinki_library_asko.HelsinkiLibraryAskoADFS',
     'auth_backends.helsinki_username.HelsinkiUsername',
     'yletunnus.backends.YleTunnusOAuth2',
-    'social_core.backends.facebook.FacebookOAuth2',
-    'social_core.backends.github.GithubOAuth2',
     'django.contrib.auth.backends.ModelBackend',
     'auth_backends.suomifi.SuomiFiSAMLAuth',
 )

--- a/tunnistamo/tests/test_suomifi_authentication.py
+++ b/tunnistamo/tests/test_suomifi_authentication.py
@@ -296,8 +296,8 @@ def test_suomifi_logout_sp_request_no_social_user(django_client, django_user_mod
 
     # If social user does not exist only Django logout is performed
     assert not django_client.cookies.get('sso-sessionid').value
-    assert logout_page_response.status_code == 302
-    assert logout_page_response.url == REDIRECT_URI
+    assert logout_page_response.status_code == 200
+    assert 'href="{}"'.format(REDIRECT_URI) in str(logout_page_response.content)
 
 
 @pytest.mark.django_db

--- a/tunnistamo/urls.py
+++ b/tunnistamo/urls.py
@@ -24,7 +24,8 @@ from services.views import ReportView
 from tunnistamo import social_auth_urls
 from users.api import TunnistamoAuthorizationView, UserConsentViewSet, UserLoginEntryViewSet
 from users.views import (
-    LoginView, LogoutView, TunnistamoOidcAuthorizeView, TunnistamoOidcEndSessionView, TunnistamoOidcTokenView
+    AuthoritativeLogoutRedirectView, LoginView, TunnistamoOidcAuthorizeView, TunnistamoOidcEndSessionView,
+    TunnistamoOidcTokenView
 )
 
 from .api import GetJWTView, UserView
@@ -62,13 +63,14 @@ router.register('user_consent', UserConsentViewSet)
 v1_scope_path = path('scope/', ScopeListView.as_view(), name='scope-list')
 v1_api_path = path('v1/', include((router.urls + [v1_scope_path], 'v1')))
 
+
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('admin/report/', staff_member_required(ReportView.as_view())),
     path('api-tokens/', get_api_tokens_view),
     path('accounts/profile/', show_login),
     path('accounts/login/', LoginView.as_view()),
-    path('accounts/logout/', LogoutView.as_view()),
+    path('accounts/logout/', AuthoritativeLogoutRedirectView.as_view()),
     path('accounts/', include(auth_backends.urls, namespace='auth_backends')),
     path('accounts/', include(social_auth_urls, namespace='social')),
     path('oauth2/applications/', permission_denied),
@@ -83,7 +85,7 @@ urlpatterns = [
     path('user/', UserView.as_view()),
     path('jwt-token/', GetJWTView.as_view()),
     path('login/', LoginView.as_view()),
-    path('logout/', LogoutView.as_view()),
+    path('logout/', AuthoritativeLogoutRedirectView.as_view()),
     v1_api_path,
     path('docs/', include_docs_urls(title='Tunnistamo API v1', patterns=[v1_api_path],
                                     generator_class=AllEnglishSchemaGenerator)),

--- a/users/templates/registration/logged_out.html
+++ b/users/templates/registration/logged_out.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block content %}
+<p>{% trans "You have been logged out of City of Helsinki services." %}</p>
+
+{% if backend and backend.persistent_session_warning %}
+<p><strong>{{ backend.persistent_session_warning }}</strong>
+{% trans "whose credentials you originally used to log in to City of Helsinki services." %}</p>
+
+<p><strong>{{ backend.persistent_session_final_warning }}</strong></p>
+
+<div class="well">
+    <p>{{ backend.persistent_session_suggestion }}</p>
+    <p><strong><a href="{{ backend.user_facing_url }}">{{ backend.persistent_session_link }}</a></strong></p>
+</div>
+
+{% endif %}
+
+{% if post_logout_redirect_uri %}
+<p><a href="{{post_logout_redirect_uri}}">{% trans "Return" %}</a></p>
+{% endif %}
+{% endblock %}

--- a/users/templates/registration/logged_out.html
+++ b/users/templates/registration/logged_out.html
@@ -4,15 +4,35 @@
 {% block content %}
 <p>{% trans "You have been logged out of City of Helsinki services." %}</p>
 
-{% if backend and backend.persistent_session_warning %}
-<p><strong>{{ backend.persistent_session_warning }}</strong>
-{% trans "whose credentials you originally used to log in to City of Helsinki services." %}</p>
+{% if backend and backend.user_facing_url %}
 
-<p><strong>{{ backend.persistent_session_final_warning }}</strong></p>
+<p><strong>
+  {% blocktrans trimmed with name_logged_in=backend.name_logged_in_to %}
+  Please note that you are still logged in to {{ name_logged_in }},
+  whose credentials you originally used to log in to City of Helsinki services.
+  {% endblocktrans %}
+</strong></p>
+
+<p><strong>
+  {% blocktrans trimmed with name_access=backend.name_access name_logout=backend.name_logout_from %}
+  If access to this device is shared by other users,
+  the next user will be able to access your {{ name_access }} account
+  unless you explicitly log out from {{ name_logout }}.
+  {% endblocktrans %}
+</strong></p>
 
 <div class="well">
-    <p>{{ backend.persistent_session_suggestion }}</p>
-    <p><strong><a href="{{ backend.user_facing_url }}">{{ backend.persistent_session_link }}</a></strong></p>
+<p>
+  {% blocktrans trimmed with name_goto=backend.name_goto name_genetive=backend.name_genetive url=backend.user_facing_url%}
+  Go back to {{ name_goto }} to log yourself out using {{ name_genetive }} own logout feature.
+  {% endblocktrans %}
+</p>
+<p><strong><a href="{{ backend.user_facing_url }}">
+  {% blocktrans trimmed with name_goto=backend.name_goto %}
+  Go to {{ name_goto }}
+  {% endblocktrans %}
+</a></strong></p>
+
 </div>
 
 {% endif %}

--- a/users/tests/test_logout_view.py
+++ b/users/tests/test_logout_view.py
@@ -3,6 +3,10 @@ from django.contrib import auth
 from django.utils.crypto import get_random_string
 
 
+def link_to_url_found_in_response(response, url):
+    return 'href="{}"'.format(url) in str(response.content)
+
+
 @pytest.mark.django_db
 def test_logout(client, user_factory):
     password = get_random_string()
@@ -13,7 +17,7 @@ def test_logout(client, user_factory):
     user = auth.get_user(client)
     assert user.is_authenticated
 
-    response = client.get('/logout/')
+    response = client.get('/logout/', follow=True)
 
     assert response.status_code == 200
 
@@ -21,23 +25,30 @@ def test_logout(client, user_factory):
     assert not user.is_authenticated
 
 
-@pytest.mark.parametrize('next, expected', (
+@pytest.mark.parametrize('endpoint, uri_param', (
+    ('logout', 'next'),
+    ('openid/end-session', 'post_logout_redirect_uri'),
+))
+@pytest.mark.parametrize('_next, expected', (
     ('http://example.com/', 'http://example.com/'),
     ('https://example2.com/', 'https://example2.com/'),
 ))
 @pytest.mark.django_db
-def test_logout_redirect_next(client, user_factory, next, expected, application_factory):
+def test_logout_redirect_next(client, user_factory, _next, expected, application_factory, endpoint, uri_param):
     app = application_factory(post_logout_redirect_uris=expected, redirect_uris=['http://example.com/'])
     app.save()
-    response = client.get('/logout/', {
-        'next': next,
-    })
+    response = client.get('/{}/'.format(endpoint), {
+        uri_param: _next,
+    }, follow=True)
 
-    assert response.status_code == 302
-    assert response['location'] == expected
+    assert response.status_code == 200
+    assert link_to_url_found_in_response(response, _next)
 
 
-@pytest.mark.parametrize('next', (
+@pytest.mark.parametrize('endpoint, uri_param', (
+    ('logout', 'next'),
+    ('openid/end-session', 'post_logout_redirect_uri')))
+@pytest.mark.parametrize('_next', (
     None,
     '',
     get_random_string(),
@@ -50,16 +61,19 @@ def test_logout_redirect_next(client, user_factory, next, expected, application_
     'mailto:test@example.com',
 ))
 @pytest.mark.django_db
-def test_logout_no_redirect_on_invalid_next(client, user_factory, next):
-    response = client.get('/logout/', {
-        'next': next,
-    })
-
+def test_logout_no_redirect_on_invalid_next(client, user_factory, _next, endpoint, uri_param):
+    response = client.get('/{}/'.format(endpoint), {
+        uri_param: _next,
+    }, follow=True)
     assert response.status_code == 200
+    assert not link_to_url_found_in_response(response, _next)
 
 
+@pytest.mark.parametrize('endpoint, uri_param', (
+    ('logout', 'next'),
+    ('openid/end-session', 'post_logout_redirect_uri')))
 @pytest.mark.django_db
-def test_logout_redirect_next_authenticated(client, user_factory, application_factory):
+def test_logout_redirect_next_authenticated(client, user_factory, application_factory, endpoint, uri_param):
     app = application_factory(post_logout_redirect_uris='http://example.com/', redirect_uris=['http://example.com/'])
     app.save()
 
@@ -68,11 +82,8 @@ def test_logout_redirect_next_authenticated(client, user_factory, application_fa
 
     client.login(username=user.username, password=password)
 
-    params = {
-        "next": "http://example.com/",
-    }
+    params = {uri_param: 'http://example.com/'}
+    response = client.get('/{}/'.format(endpoint), params, follow=True)
 
-    response = client.get('/logout/', params)
-
-    assert response.status_code == 302
-    assert response['location'] == params['next']
+    assert response.status_code == 200
+    assert link_to_url_found_in_response(response, 'http://example.com/')

--- a/users/tests/test_user_consent_api.py
+++ b/users/tests/test_user_consent_api.py
@@ -79,7 +79,7 @@ def test_get(user_api_client, endpoint, scope_included, service):
 
         assert oidc_scope.keys() == {'id', 'name', 'description'}
         assert oidc_scope['id'] == 'email'
-        assert oidc_scope['name'] == {'fi': 'Sähköposti', 'sv': 'E-postadress', 'en': 'Email'}
+        assert oidc_scope['name'] == {'fi': 'Sähköpostiosoite', 'sv': 'E-postadress', 'en': 'Email'}
         assert 'en' in oidc_scope['description']
 
         assert api_scope.keys() == {'id', 'name', 'description'}

--- a/yletunnus/backends.py
+++ b/yletunnus/backends.py
@@ -1,4 +1,5 @@
 import jwt
+from django.utils.translation import gettext as _
 from social_core.backends.oauth import BaseOAuth2
 
 
@@ -47,3 +48,20 @@ class YleTunnusOAuth2(BaseOAuth2):
             issuer='https://auth.api.yle.fi', audience=self.setting('APP_ID')
         )
         return data
+
+    persistent_session_warning = _(
+        "Please note that you are still logged in to Yle Tunnus"
+    )
+    persistent_session_suggestion = _(
+        "Go back to Yle Tunnus where you can log yourself out "
+        "in the usual manner:"
+    )
+    persistent_session_link = _(
+        "Go to Yle Tunnus"
+    )
+    persistent_session_final_warning = _(
+        "If access to this device is shared by other users, "
+        "the next user will be able to access your Yle account "
+        "unless you explicitly log out from Yle Tunnus."
+    )
+    user_facing_url = 'https://tunnus.yle.fi/'

--- a/yletunnus/backends.py
+++ b/yletunnus/backends.py
@@ -1,5 +1,5 @@
 import jwt
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext, pgettext
 from social_core.backends.oauth import BaseOAuth2
 
 
@@ -49,19 +49,11 @@ class YleTunnusOAuth2(BaseOAuth2):
         )
         return data
 
-    persistent_session_warning = _(
-        "Please note that you are still logged in to Yle Tunnus"
-    )
-    persistent_session_suggestion = _(
-        "Go back to Yle Tunnus where you can log yourself out "
-        "in the usual manner:"
-    )
-    persistent_session_link = _(
-        "Go to Yle Tunnus"
-    )
-    persistent_session_final_warning = _(
-        "If access to this device is shared by other users, "
-        "the next user will be able to access your Yle account "
-        "unless you explicitly log out from Yle Tunnus."
-    )
+    user_facing_name = 'Yle Tunnus'
     user_facing_url = 'https://tunnus.yle.fi/'
+    name_baseform = gettext('Yle Tunnus')
+    name_access = pgettext('access to []', 'Yle Tunnus')
+    name_genetive = pgettext('genetive form', 'Yle Tunnus')
+    name_logged_in_to = pgettext('logged in to []', 'Yle Tunnus')
+    name_logout_from = pgettext('log out from []', 'Yle Tunnus')
+    name_goto = pgettext('go to []', 'Yle Tunnus')


### PR DESCRIPTION
Features: warning about lingering 3rd party IDP sessions.

Internationalized template and warnings.

Implement redirection from old logout screens to new,
with query parameter translation.

Adjust tests so that they no longer expect post logout
HTTP redirects, but expect a 200 response with HTML with
a link to the post logout uri.