### PR TITLE
Fix CORS tests for openid configuration URL

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -291,7 +291,7 @@ LOGGING = {
 }
 
 CORS_ORIGIN_ALLOW_ALL = False
-CORS_URLS_REGEX = r'.*/(\.well-known/openid-configuration|v1|openid|api-tokens|jwt-token)/.*'
+CORS_URLS_REGEX = r'.*/(\.well-known/openid-configuration|v1|openid|api-tokens|jwt-token).*'
 
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'users.Application'

--- a/users/tests/test_cors_middleware.py
+++ b/users/tests/test_cors_middleware.py
@@ -45,10 +45,10 @@ def assert_database_state_consistent(urls, cut):
 
 
 @pytest.mark.parametrize("application_url,cors_enabled,destructive_operation", [  # noqa: C901
-    ('/.well-known/openid-configuration/', True, 'delete'),
+    ('/.well-known/openid-configuration', True, 'delete'),
     ('/api-tokens/', True, 'erase'),
     ('/openid/jwks/', True, 'delete'),
-    ('/openid/.well-known/openid-configuration/', True, 'erase'),
+    ('/openid/.well-known/openid-configuration', True, 'erase'),
     ('/login/', False, 'delete'),
     ('/logout/', False, 'erase'),
     ('/admin/', False, 'delete'),


### PR DESCRIPTION
Tests /.well-known/openid-configuration URLS ended with slash. That is incorrect:
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest