### PR TITLE
Fix auto-generated API documentation

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -306,6 +306,7 @@ REST_FRAMEWORK = {
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
     ),
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 


### PR DESCRIPTION
Changes the `DEFAULT_SCHEMA_CLASS` setting for drf as suggested in:
https://www.django-rest-framework.org/community/3.10-announcement/#continuing-to-use-coreapi

Django REST framework 3.10 changed the `DEFAULT_SCHEMA_CLASS` into `rest_framework.schemas.openapi.AutoSchema`. This made the API documentation at `/docs/` fail with an `AttributeError`.