### PR TITLE
Specify all allowed APIs in the same API token

### DIFF
--- a/oidc_apis/api_tokens.py
+++ b/oidc_apis/api_tokens.py
@@ -27,17 +27,22 @@ def get_api_tokens_by_access_token(token, request=None):
     # Group API scopes by the API identifiers
     scopes_by_api = defaultdict(list)
     for api_scope in allowed_api_scopes:
-        scopes_by_api[api_scope.api.identifier].append(api_scope)
+        # TODO: group by api domain
+        scopes_by_api[api_scope.api.identifier] = list(allowed_api_scopes)
 
     return {
-        api_identifier: generate_api_token(scopes, token, request)
+        api_identifier: generate_api_token(api_identifier, scopes, token, request)
         for (api_identifier, scopes) in scopes_by_api.items()
     }
 
 
-def generate_api_token(api_scopes, token, request=None):
+def generate_api_token(api_identifier, api_scopes, token, request=None):
     assert api_scopes
-    api = api_scopes[0].api
+    api = None
+    for api_scope in api_scopes:
+        if api_scope.api.identifier == api_identifier:
+            api = api_scope.api
+    assert api
     audience = api.oidc_client.client_id
     req_scopes = api.required_scopes
 


### PR DESCRIPTION
Previously, only the API that matches the audience of the token
was specified in its payload. In order to make one token work
for multiple APIs, we need to list all allowed APIs connected
to the "API_AUTHORIZATION_FIELD" domain.

Changes token payload from this:
```
{
  "iss": "http://tunnistamo-backend:8000/openid",
  "sub": "24ec5ee2-3047-11e9-a979-0242ac170003",
  "aud": "https://api.hel.fi/auth/profiles",
  "exp": 1575496311,
  "iat": 1575492874,
  "auth_time": 1575446321,
  "name": "Igor Davydychev",
  "given_name": "Igor",
  "family_name": "Davydychev",
  "nickname": "Igor",
  "email": "igor@example.com",
  "email_verified": false,
  "amr": "github",
  "https://api.hel.fi/auth": [
    "profiles"
  ]
}
```
to this 
```
{
  "iss": "http://tunnistamo-backend:8000/openid",
  "sub": "24ec5ee2-3047-11e9-a979-0242ac170003",
  "aud": "https://api.hel.fi/auth/profiles",
  "exp": 1575496311,
  "iat": 1575492874,
  "auth_time": 1575446321,
  "name": "Igor Davydychev",
  "given_name": "Igor",
  "family_name": "Davydychev",
  "nickname": "Igor",
  "email": "igor@example.com",
  "email_verified": false,
  "amr": "github",
  // LIST OF ALL ALLOWED APIS UNDER THE SAME DOMAIN 
  "https://api.hel.fi/auth": [
    "berths",
    "profiles"
  ]
}
```