### PR TITLE
Security upgrades for Django, Pillow and ecdsa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ coreapi==2.3.3
 coreschema==0.0.4         # via coreapi
 cryptography==2.3.1
 defusedxml==0.5.0         # via python3-openid, python3-saml, social-auth-core
-django==2.1.11
+django==2.1.15
 django-allauth==0.36.0
 django-appconf==1.0.2     # via django-compressor
 django-bootstrap3==10.0.1
@@ -32,7 +32,7 @@ django-sass-processor==0.7
 git+https://github.com/City-of-Helsinki/django-translation-checker.git@master#egg=django-translation-checker==0.1
 djangorestframework==3.10.2
 drf-oidc-auth==0.9        # via django-helusers
-ecdsa==0.13               # via python-jose
+ecdsa==0.15               # via python-jose
 future==0.16.0            # via pyjwkest, python-jose
 geoip2==2.9.0
 idna==2.6                 # via cryptography, requests
@@ -45,7 +45,7 @@ lxml==4.2.6               # via xmlsec
 markupsafe==1.0           # via jinja2
 maxminddb==1.4.1          # via geoip2
 oauthlib==2.1.0           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
-pillow==5.1.0
+pillow==7.0.0
 pkgconfig==1.3.1          # via xmlsec
 polib==1.1.0              # via django-translation-checker
 psycopg2==2.8.3
@@ -65,7 +65,7 @@ requests-oauthlib==1.0.0  # via django-allauth, social-auth-core
 rjsmin==1.0.12            # via django-compressor
 rsa==4.0                  # via python-jose
 ruamel.yaml==0.15.89
-six==1.11.0               # via cryptography, isodate, libsass, pyjwkest, python-jose, social-auth-app-django, social-auth-core
+six==1.11.0               # via cryptography, ecdsa, isodate, libsass, pyjwkest, python-jose, social-auth-app-django, social-auth-core
 social-auth-app-django==2.1.0
 social-auth-core[openidconnect,saml]==3.0.0
 uritemplate==3.0.0        # via coreapi


### PR DESCRIPTION
Upgrade these to clear the requirements.io alert. Thus the alert will again become useful for detecting any new problems.