### PR TITLE
Only allow embedding the authorize endpoint in IFRAME by default

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -20,7 +20,7 @@ env = environ.Env(
     SECRET_KEY=(str, ""),
     DATABASE_URL=(str, ""),
     ALLOWED_HOSTS=(list, []),
-    ALLOW_EMBEDDING_IN_FRAME=(bool, True),
+    ALLOW_EMBEDDING_IN_FRAME=(bool, False),
 
     STATIC_URL=(str, "/sso/static/"),
     STATIC_ROOT=(str, os.path.join(BASE_DIR, 'static')),
@@ -131,8 +131,10 @@ MIDDLEWARE = [
     'tunnistamo.middleware.ContentSecurityPolicyMiddleware'
 ]
 
-# Traditional (heh) silent renew requires embedding the login endpoint
-# in IFRAME. Thus this must be enabled (True), if silent renew is wanted.
+# If you need to allow embedding tunnistamo in FRAME, this is the setting
+# to toggle. Note that "openid/authorize/" is always allowed to be embedded
+# as that is required for traditional silent renewal as used in implicit
+# flow without refresh tokens.
 if not env('ALLOW_EMBEDDING_IN_FRAME'):
     # Middleware position likely does not matter, this just puts it in the
     # same place where it was before adding this switch.

--- a/tunnistamo/urls.py
+++ b/tunnistamo/urls.py
@@ -7,6 +7,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpResponse
 from django.urls import include, path, re_path
 from django.utils import translation
+from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.defaults import permission_denied
 from oidc_provider.views import ProviderInfoView as OIDCProviderInfoView
@@ -74,7 +75,7 @@ urlpatterns = [
     path('oauth2/applications/', permission_denied),
     path('oauth2/authorize/', TunnistamoAuthorizationView.as_view(), name="oauth2_authorize"),
     path('oauth2/', include(oauth2_provider.urls, namespace='oauth2_provider')),
-    re_path(r'^openid/authorize/?$', TunnistamoOidcAuthorizeView.as_view(), name='authorize'),
+    re_path(r'^openid/authorize/?$', xframe_options_exempt(TunnistamoOidcAuthorizeView.as_view()), name='authorize'),
     re_path(r'^openid/end-session/?$', TunnistamoOidcEndSessionView.as_view(), name='end-session'),
     re_path(r'^openid/token/?$', csrf_exempt(TunnistamoOidcTokenView.as_view()), name='token'),
     path('openid/', include(oidc_provider.urls, namespace='oidc_provider')),


### PR DESCRIPTION
Previous commit (cbbd1d19ee2f0326c1e1289c65b8b5594d6ed3bd ) changed the default to allow embedding the whole application in IFRAME. Silent renew only requires access to the authorize-endpoint, which is now always allowed to be framed. The switch to allow embedding the
whole application is still present, but defaults to False.