### PR TITLE
Update Python social core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ cryptography==3.2
     #   -r requirements.in
     #   jwcrypto
     #   pyjwt
+    #   social-auth-core
 defusedxml==0.5.0
     # via
     #   python3-openid
@@ -181,7 +182,7 @@ six==1.11.0
     #   social-auth-core
 social-auth-app-django==2.1.0
     # via -r requirements.in
-social-auth-core[openidconnect,saml]==3.0.0
+social-auth-core[openidconnect,saml]==3.3.3
     # via
     #   -r requirements.in
     #   social-auth-app-django

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -353,6 +353,13 @@ SASS_PRECISION = 8
 TEST_NON_SERIALIZED_APPS = ['adfs_provider']
 
 # Social Auth
+
+# social-core from version >= 3.3.0 allows providers to update user fields
+# even if they already have a value. The code in question will break when
+# trying to update "ad_groups" due to it being a many-to-many relation.
+# Instead AD groups are updated in their own pipeline step.
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['ad_groups']
+
 SOCIAL_AUTH_PIPELINE = (
     # Get the information we can about the user and return it in a simple
     # format to create the user instance later. On some cases the details are


### PR DESCRIPTION
social_core 3.3.0 began to update existing user attributes from incoming logins. Attributes used by Django ('username', 'id', 'pk', 'email', 'password', 'is_active', 'is_staff', 'is_superuser') are blacklisted by default. However 'ad_groups' was not. This broke the pipeline, as AD groups are a M2M relation. Workaround was just blacklisting `ad_groups` attribute as well.