### PR TITLE
Fix broken dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ jwcrypto==0.6.0
 libsass==0.14.5
 lxml==4.2.6               # via xmlsec
 markupsafe==1.0           # via jinja2
-maxminddb==1.4.1          # via geoip2
+maxminddb==1.5.1          # via geoip2
 oauthlib==2.1.0           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
 pillow==7.0.0
 pkgconfig==1.3.1          # via xmlsec

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ jinja2==2.10.1            # via coreschema
 jwcrypto==0.6.0
 libsass==0.14.5
 lxml==4.2.6               # via xmlsec
-markupsafe==1.0           # via jinja2
+markupsafe==1.1           # via jinja2
 maxminddb==1.5.1          # via geoip2
 oauthlib==2.1.0           # via django-oauth-toolkit, requests-oauthlib, social-auth-core
 pillow==7.0.0


### PR DESCRIPTION
Apparently setuptools has "[removed some deprecated code][0]" thus [breaking the build][1]. To fix the build the broken dependencies are upgraded to their latest versions.

[0]: https://github.com/pallets/markupsafe/issues/57#issuecomment-597105876
[1]: https://gitlab.com/City-of-Helsinki/KuVa/github-mirrors/tunnistamo/-/jobs/529824243