### PR TITLE
Define default database (local postgres / "tunnistamo") declaratively

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -18,7 +18,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 env = environ.Env(
     DEBUG=(bool, False),
     SECRET_KEY=(str, ""),
-    DATABASE_URL=(str, "postgres://tunnistamo"),
+    DATABASE_URL=(str, "postgres:///tunnistamo"),
     ALLOWED_HOSTS=(list, []),
     ALLOW_CROSS_SITE_SESSION_COOKIE=(bool, False),
 

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -18,7 +18,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 env = environ.Env(
     DEBUG=(bool, False),
     SECRET_KEY=(str, ""),
-    DATABASE_URL=(str, ""),
+    DATABASE_URL=(str, "postgres://tunnistamo"),
     ALLOWED_HOSTS=(list, []),
     ALLOW_CROSS_SITE_SESSION_COOKIE=(bool, False),
 
@@ -186,15 +186,7 @@ WSGI_APPLICATION = 'tunnistamo.wsgi.application'
 #
 # Database
 #
-if env.db("DATABASE_URL"):
-    DATABASES = {"default": env.db("DATABASE_URL")}
-else:
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql_psycopg2',
-            'NAME': 'tunnistamo',
-        }
-    }
+DATABASES = {"default": env.db("DATABASE_URL")}
 
 #
 # Internationalization


### PR DESCRIPTION
This makes the default easier to parse from settings.py. Also removes the annoying warning from django-environ about missing db settings.