### PR TITLE
Fix base template reference in email verification template

### DIFF
--- a/users/templates/account/signup_closed.html
+++ b/users/templates/account/signup_closed.html
@@ -1,4 +1,4 @@
-{% extends "account/base.html" %}
+{% extends "base.html" %}
 
 {% load i18n %}
 


### PR DESCRIPTION
django-allauth 0.43.0 renamed a template to use a name
already used by the signup closed template. This is fixed
by using the correct reference in our template.

https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst