### PR TITLE
Keycloak "suomi.fi" backend

### DIFF
--- a/auth_backends/helsinki_identity.py
+++ b/auth_backends/helsinki_identity.py
@@ -1,0 +1,18 @@
+from social_core.backends.open_id_connect import OpenIdConnectAuth
+
+
+class HelsinkiIdentity(OpenIdConnectAuth):
+    """Authenticates the user against suomi.fi (phase1) and all other
+       social logins (phase2)."""
+    name = 'helidentity'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.OIDC_ENDPOINT = self.setting('OIDC_ENDPOINT')
+
+    def get_user_uuid(self, details, response):
+        # We explicitly want to use the UUID from the keycloak provided
+        # token as our own identity
+        uid = self.get_user_id(details, response)
+
+        return uid

--- a/auth_backends/helsinki_tunnistus_suomifi.py
+++ b/auth_backends/helsinki_tunnistus_suomifi.py
@@ -1,10 +1,12 @@
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 
 
-class HelsinkiIdentity(OpenIdConnectAuth):
-    """Authenticates the user against suomi.fi (phase1) and all other
-       social logins (phase2)."""
-    name = 'helidentity'
+class HelsinkiTunnistus(OpenIdConnectAuth):
+    """Authenticates the user against Keycloak proxying to suomi.fi
+       This is plain OIDC backend, except that it uses the Keycloak provided
+       user id ("sub" field) as the local user identifier.
+    """
+    name = 'heltunnistussuomifi'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/auth_backends/helsinki_tunnistus_suomifi.py
+++ b/auth_backends/helsinki_tunnistus_suomifi.py
@@ -15,6 +15,4 @@ class HelsinkiTunnistus(OpenIdConnectAuth):
     def get_user_uuid(self, details, response):
         # We explicitly want to use the UUID from the keycloak provided
         # token as our own identity
-        uid = self.get_user_id(details, response)
-
-        return uid
+        return self.get_user_id(details, response)

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -47,6 +47,13 @@ env = environ.Env(
     # Client secret
     SOCIAL_AUTH_HELUSERNAME_SECRET=(str, ""),
 
+    # Helsinki Tunnistus Keycloak proxying to suomi.fi
+    SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_OIDC_ENDPOINT=(str, ""),
+    # Client ID
+    SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_KEY=(str, ""),
+    # Client secret
+    SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_SECRET=(str, ""),
+
     SOCIAL_AUTH_ESPOO_ADFS_KEY=(str, ""),
     SOCIAL_AUTH_ESPOO_ADFS_SECRET=(str, ""),
 
@@ -151,7 +158,7 @@ AUTHENTICATION_BACKENDS = (
     'auth_backends.google.GoogleOAuth2CustomName',
     'auth_backends.adfs.helsinki_library_asko.HelsinkiLibraryAskoADFS',
     'auth_backends.helsinki_username.HelsinkiUsername',
-    'auth_backends.helsinki_tunnistus.HelsinkiIdentity',
+    'auth_backends.helsinki_tunnistus_suomifi.HelsinkiTunnistus',
     'yletunnus.backends.YleTunnusOAuth2',
     'django.contrib.auth.backends.ModelBackend',
     'auth_backends.suomifi.SuomiFiSAMLAuth',
@@ -453,6 +460,10 @@ SOCIAL_AUTH_ESPOO_ADFS_SECRET = env("SOCIAL_AUTH_ESPOO_ADFS_SECRET")
 SOCIAL_AUTH_HELUSERNAME_OIDC_ENDPOINT = env("SOCIAL_AUTH_HELUSERNAME_OIDC_ENDPOINT")
 SOCIAL_AUTH_HELUSERNAME_KEY = env("SOCIAL_AUTH_HELUSERNAME_KEY")
 SOCIAL_AUTH_HELUSERNAME_SECRET = env("SOCIAL_AUTH_HELUSERNAME_SECRET")
+
+SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_OIDC_ENDPOINT = env("SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_OIDC_ENDPOINT")
+SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_KEY = env("SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_KEY")
+SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_SECRET = env("SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_SECRET")
 
 
 ###

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -151,6 +151,7 @@ AUTHENTICATION_BACKENDS = (
     'auth_backends.google.GoogleOAuth2CustomName',
     'auth_backends.adfs.helsinki_library_asko.HelsinkiLibraryAskoADFS',
     'auth_backends.helsinki_username.HelsinkiUsername',
+    'auth_backends.helsinki_tunnistus.HelsinkiIdentity',
     'yletunnus.backends.YleTunnusOAuth2',
     'django.contrib.auth.backends.ModelBackend',
     'auth_backends.suomifi.SuomiFiSAMLAuth',

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -387,8 +387,7 @@ SOCIAL_AUTH_PIPELINE = (
     # Checks if the current social-account is already associated in the site.
     'social_core.pipeline.social_auth.social_user',
 
-
-    # Add `new_uuid` argument to the pipeline.
+    # Add `uuid` argument to the pipeline.
     'users.pipeline.get_user_uuid',
     # Sets the `username` argument.
     'users.pipeline.get_username',
@@ -464,7 +463,8 @@ SOCIAL_AUTH_HELUSERNAME_SECRET = env("SOCIAL_AUTH_HELUSERNAME_SECRET")
 SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_OIDC_ENDPOINT = env("SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_OIDC_ENDPOINT")
 SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_KEY = env("SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_KEY")
 SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_SECRET = env("SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_SECRET")
-
+# Helsinki Tunnistus (Keycloak) suomi.fi sets the uuid for easier migration
+SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_USER_FIELDS = ['username', 'email', 'uuid']
 
 ###
 # The following section contains values required by Social Auth Suomi.fi

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -14,18 +14,23 @@ logger = logging.getLogger(__name__)
 
 
 def get_user_uuid(details, backend, response, user=None, *args, **kwargs):
-    """Add `new_uuid` argument to the pipeline.
+    """Add `uuid` argument to the pipeline.
 
-    Makes sure that a `new_uuid` argument is available to other
-    pipeline entries.
+    Makes `uuid` argument available to other pipeline entries.
 
     If the backend provides `get_user_uuid` method (as is the case with
-    the ADFS backends), it is used to generate the UUID. Otherwise, the
-    UUID is generated with `uuid.uuid1` function.
+    the ADFS backends and Keycloak suomi.fi backend), it is used to
+    generate the UUID. Otherwise, the UUID is generated with `uuid.uuid1`
+    function.
+
+    The argument is named same as the django-helusers `uuid` field.
+    This allows syncing the helusers `uuid`-field with uuid generated
+    here using SOCIAL_AUTH_backend_name_USER_FIELDS.
     """
+
     if user and getattr(user, 'uuid'):
         return {
-            'new_uuid': user.uuid,
+            'uuid': user.uuid,
         }
     if callable(getattr(backend, 'get_user_uuid', None)):
         new_uuid = backend.get_user_uuid(details, response)
@@ -33,7 +38,7 @@ def get_user_uuid(details, backend, response, user=None, *args, **kwargs):
         new_uuid = uuid.uuid1()
 
     return {
-        'new_uuid': new_uuid,
+        'uuid': new_uuid,
     }
 
 
@@ -47,7 +52,7 @@ def get_username(strategy, user=None, *args, **kwargs):
     storage = strategy.storage
 
     if not user:
-        user_uuid = kwargs.get('new_uuid')
+        user_uuid = kwargs.get('uuid')
         if not user_uuid:
             return
 


### PR DESCRIPTION
Add a backend for Keycloak providing suomi.fi authentication. This is a separate OIDC backend for two reasons:
* We want to use Keycloak provided UUId as our own user id, to make future migration to Keycloak easier / possible
* Python Social Auth needs a separate backend to provide separately configured instance
