### PR TITLE
Add a toggle for the email duplicate check

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -28,6 +28,8 @@ env = environ.Env(
     MEDIA_URL=(str, '/media/'),
     NODE_MODULES_ROOT=(str, os.path.join(BASE_DIR, 'node_modules')),
 
+    ALLOW_DUPLICATE_EMAILS=(bool, False),
+
     # Authentication settings
     SOCIAL_AUTH_FACEBOOK_KEY=(str, ""),
     SOCIAL_AUTH_FACEBOOK_SECRET=(str, ""),
@@ -393,9 +395,10 @@ SOCIAL_AUTH_PIPELINE = (
     'users.pipeline.get_username',
     # Enforce email address.
     'users.pipeline.require_email',
-    # Deny duplicate email or associate to an existing user by email
-    'users.pipeline.associate_by_email',
 
+    # Disallows a new login with the same email address and different
+    # provider except when ALLOW_DUPLICATE_EMAILS is true
+    'users.pipeline.associate_by_email',
     # Make up a username for this person, appends a random string at the end if
     # there's any collision.
     # 'social_core.pipeline.user.get_username',
@@ -429,6 +432,8 @@ SOCIAL_AUTH_PIPELINE = (
     # Save last login backend to user data
     'users.pipeline.save_social_auth_backend'
 )
+
+ALLOW_DUPLICATE_EMAILS = env("ALLOW_DUPLICATE_EMAILS")
 
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['email', 'first_name', 'last_name']
 

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -364,11 +364,17 @@ TEST_NON_SERIALIZED_APPS = ['adfs_provider']
 
 # Social Auth
 
+# Social Auth by default protects the email field (among others) from changes
+# We want to set the email from the incoming login.
+NO_DEFAULT_PROTECTED_USER_FIELDS = True
+TUNNISTAMO_PROTECTED_FIELDS = ['username', 'id', 'pk', 'password',
+                               'is_active', 'is_staff', 'is_superuser', ]
+
 # social-core from version >= 3.3.0 allows providers to update user fields
 # even if they already have a value. The code in question will break when
 # trying to update "ad_groups" due to it being a many-to-many relation.
 # Instead AD groups are updated in their own pipeline step.
-SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['ad_groups']
+SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['ad_groups'] + TUNNISTAMO_PROTECTED_FIELDS
 
 SOCIAL_AUTH_PIPELINE = (
     # Get the information we can about the user and return it in a simple

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -73,7 +73,9 @@ def require_email(strategy, details, backend, user=None, *args, **kwargs):
     `details` received from the social auth doesn't include an email
     address.
     """
+    logger.debug(f"enforcing email; user:{user}; details:{details}, backend: {backend.name}")
     if user:
+        logger.debug(f"user: {user} already exists. Will not check email.")
         return
     # Suomi.fi returns PRC(VRK) information, which often doesn't inclue email address
     if backend.name == 'suomifi':

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -160,6 +160,14 @@ def update_ad_groups(details, backend, user=None, *args, **kwargs):
 
 
 def check_existing_social_associations(backend, strategy, user=None, social=None, *args, **kwargs):
+    """Deny adding additional social auths
+
+    social_core.pipeline.social_auth.associate_user would automatically
+    add additional social auths for the user, if they succesfully
+    authenticated to another IdP while holding a session with Tunnistamo.
+    We don't want this to happen, as there is no interface for managing
+    additional IdPs.
+    """
     logger.debug(f"starting check for existing social assoc; user:{user}; backend: {backend.name}; social:{social}")
     if user and not social:
         social_set = user.social_auth.all()


### PR DESCRIPTION
Allows toggling the email duplicate check using ALLOW_DUPLICATE_EMAILS. For backwards compatibility this defaults too false.

Also piggybacked is change that allows the incoming e-mail from the IdP to overwrite the existing e-mail.