### PR TITLE
Allow certain backends to be exempt from email requirement

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -30,6 +30,7 @@ env = environ.Env(
     NODE_MODULES_ROOT=(str, os.path.join(BASE_DIR, 'node_modules')),
 
     ALLOW_DUPLICATE_EMAILS=(bool, False),
+    EMAIL_EXEMPT_AUTH_BACKENDS=(list,[]),
 
     # Authentication settings
     SOCIAL_AUTH_FACEBOOK_KEY=(str, ""),
@@ -175,6 +176,8 @@ RESTRICTED_AUTHENTICATION_BACKENDS = (
     'auth_backends.suomifi.SuomiFiSAMLAuth',
 )
 RESTRICTED_AUTHENTICATION_TIMEOUT = 60 * 60
+
+EMAIL_EXEMPT_AUTH_BACKENDS = env("EMAIL_EXEMPT_AUTH_BACKENDS")
 
 ROOT_URLCONF = 'tunnistamo.urls'
 

--- a/tunnistamo/test_settings.py
+++ b/tunnistamo/test_settings.py
@@ -83,3 +83,5 @@ SOCIAL_AUTH_SUOMIFI_TECHNICAL_CONTACT = SOCIAL_AUTH_SUOMIFI_SUPPORT_CONTACT = {
     'emailAddress': 'teppo.testi@tunnistamo.test',
 }
 SOCIAL_AUTH_SUOMIFI_UI_LOGO = {'url': 'https://tunnistamo.test/logo.svg', 'height': '120', 'width': '240'}
+
+EMAIL_EXEMPT_AUTH_BACKENDS = ['suomifi']

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -77,8 +77,10 @@ def require_email(strategy, details, backend, user=None, *args, **kwargs):
     if user:
         logger.debug(f"user: {user} already exists. Will not check email.")
         return
-    # Suomi.fi returns PRC(VRK) information, which often doesn't inclue email address
-    if backend.name == 'suomifi':
+    # Some backends do not have email available for all their users, allow config to
+    # bypass this check. (unused suomi.fi backend is one such)
+    if backend.name in settings.EMAIL_EXEMPT_AUTH_BACKENDS:
+        logger.debug(f"backend '{backend.name}' exempt from email checks")
         return
     if details.get('email'):
         return


### PR DESCRIPTION
Some IdPs have users which might not have an email address,
especially Suomi.fi-tunnistus.