### PR TITLE
Show the "profile" debug screen when user logs in through /login

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -230,7 +230,7 @@ LOCALE_PATHS = (
 )
 
 LOGIN_URL = '/login/'
-LOGIN_REDIRECT_URL = '/profile/'
+LOGIN_REDIRECT_URL = '/accounts/profile/'
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 AUTH_USER_MODEL = 'users.User'

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -30,7 +30,7 @@ env = environ.Env(
     NODE_MODULES_ROOT=(str, os.path.join(BASE_DIR, 'node_modules')),
 
     ALLOW_DUPLICATE_EMAILS=(bool, False),
-    EMAIL_EXEMPT_AUTH_BACKENDS=(list,[]),
+    EMAIL_EXEMPT_AUTH_BACKENDS=(list, []),
 
     # Authentication settings
     SOCIAL_AUTH_FACEBOOK_KEY=(str, ""),


### PR DESCRIPTION
For some reason tunnistamo has defaulted to non-existent /profile URL for logins without redirect back to application. This just changes it to the default /accounts/login, which is marginally more useful.