### PR TITLE
Add azp (Authorized party) and loa (Level of Assurance) claims

### DIFF
--- a/oidc_apis/scopes.py
+++ b/oidc_apis/scopes.py
@@ -158,7 +158,21 @@ class SuomiFiUserAttributeScopeClaims(ScopeClaims, metaclass=SuomiFiUserAttribut
 
 class OptionalOpenIDScopeClaims(ScopeClaims):
     def scope_openid(self):
-        return {'amr': self.user.last_login_backend} if self.user.last_login_backend else {}
+        claims = {}
+
+        if self.user.last_login_backend:
+            claims['amr'] = self.user.last_login_backend
+
+        # Add the current client id to the "azp" claim (Authorized party - the party
+        # to which the ID Token was issued).
+        claims['azp'] = self.client.client_id
+
+        # Set "low" as the default "Level of Assurance". This is possibly changed in
+        # the "add_heltunnistussuomifi_loa_claim" id processing hook if the user
+        # authenticated using the heltunnistussuomifi provider.
+        claims['loa'] = 'low'
+
+        return claims
 
 
 class CombinedScopeClaims(ScopeClaims):

--- a/oidc_apis/utils.py
+++ b/oidc_apis/utils.py
@@ -58,3 +58,17 @@ def after_userlogin_hook(request, user, client):
 
     # Return None to continue the login flow
     return None
+
+
+def add_heltunnistussuomifi_loa_claim(dic, request, **kwargs):
+    """Add "loa" to the claims dictionary
+
+    This can be used in the OIDC_IDTOKEN_PROCESSING_HOOK setting to add the value of
+    the "heltunnistussuomifi_loa" session key to the id_token claims dictionary.
+
+    The session value is set in the save_loa_to_session pipeline operation if
+    the provider used was HelsinkiTunnistus."""
+    if request.session and request.session.get("heltunnistussuomifi_loa"):
+        dic["loa"] = request.session.get("heltunnistussuomifi_loa")
+
+    return dic

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -366,6 +366,7 @@ OIDC_IDTOKEN_INCLUDE_CLAIMS = True
 OIDC_IDTOKEN_SUB_GENERATOR = 'tunnistamo.oidc.sub_generator'
 OIDC_EXTRA_SCOPE_CLAIMS = 'oidc_apis.scopes.CombinedScopeClaims'
 OIDC_AFTER_USERLOGIN_HOOK = 'oidc_apis.utils.after_userlogin_hook'
+OIDC_IDTOKEN_PROCESSING_HOOK = 'oidc_apis.utils.add_heltunnistussuomifi_loa_claim'
 
 # key_manager settings for RSA Key
 KEY_MANAGER_RSA_KEY_LENGTH = 4096
@@ -454,7 +455,11 @@ SOCIAL_AUTH_PIPELINE = (
     'users.pipeline.update_ad_groups',
 
     # Save last login backend to user data
-    'users.pipeline.save_social_auth_backend'
+    'users.pipeline.save_social_auth_backend',
+
+    # Save the "loa" claim received from the Helsinki Tunnistus Keycloak to the session.
+    # This will be in turn added as a "loa" claim to the tokens Tunnistamo supplies.
+    'users.pipeline.save_loa_to_session',
 )
 
 ALLOW_DUPLICATE_EMAILS = env("ALLOW_DUPLICATE_EMAILS")

--- a/tunnistamo/tests/conftest.py
+++ b/tunnistamo/tests/conftest.py
@@ -1,0 +1,35 @@
+import datetime
+
+import pytest
+from django.utils import timezone
+from oidc_provider.models import Code
+
+from users.tests.conftest import loginmethod_factory, oidcclient_factory, user  # noqa
+
+
+@pytest.fixture
+def rsa_key():
+    from Cryptodome.PublicKey import RSA
+    from oidc_provider.models import RSAKey
+
+    key = RSA.generate(2048)
+    rsakey = RSAKey.objects.create(key=key.exportKey('PEM').decode('utf8'))
+
+    return rsakey
+
+
+@pytest.fixture()
+def oidc_code_factory():
+    def make_instance(**args):
+        args.setdefault(
+            'expires_at',
+            timezone.now() + datetime.timedelta(hours=1)
+        )
+        args.setdefault("scope", ["openid"])
+        args.setdefault("is_authentication", True)
+
+        instance = Code.objects.create(**args)
+
+        return instance
+
+    return make_instance

--- a/tunnistamo/tests/test_azp_and_loa.py
+++ b/tunnistamo/tests/test_azp_and_loa.py
@@ -1,0 +1,91 @@
+import jwt
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_id_token_has_azp_claim(
+    user,
+    client,
+    oidcclient_factory,
+    rsa_key,
+    oidc_code_factory,
+):
+    oidc_client = oidcclient_factory(
+        client_id="test_client",
+        redirect_uris=['https://tunnistamo.test/redirect_uri'],
+        response_types=["id_token"]
+    )
+
+    code = oidc_code_factory(user=user, client=oidc_client)
+
+    token_url = reverse('token')
+    post_data = {
+        'client_id': oidc_client.client_id,
+        'grant_type': 'authorization_code',
+        'redirect_uri': 'https://tunnistamo.test/redirect_uri',
+        'code': code.code,
+        'scope': 'openid',
+    }
+    token_response = client.post(token_url, post_data)
+
+    assert token_response.status_code == 200
+
+    id_token_string = token_response.json().get("id_token")
+    id_token_data = jwt.decode(id_token_string, verify=False)
+
+    assert id_token_data.get("azp") == oidc_client.client_id
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'session_loa_value,expected_loa_value',
+    [
+        (None, "low"),
+        ("low", "low"),
+        ("substantial", "substantial"),
+        ("abcdefg", "abcdefg"),
+    ]
+)
+def test_id_token_has_loa_claim_from_session(
+    user,
+    client,
+    oidcclient_factory,
+    rsa_key,
+    oidc_code_factory,
+    session_loa_value,
+    expected_loa_value,
+):
+    """Test that the loa value from the session ends up in the token
+
+    This is an implementation detail test, but we don't have a better way to test
+    this right now. Proper testing would need end-to-end tests with e.g. Selenium."""
+    oidc_client = oidcclient_factory(
+        client_id="test_client",
+        redirect_uris=['https://tunnistamo.test/redirect_uri'],
+        response_types=["id_token"]
+    )
+
+    code = oidc_code_factory(user=user, client=oidc_client)
+
+    if session_loa_value:
+        session = client.session
+        session["heltunnistussuomifi_loa"] = session_loa_value
+        session.save()
+
+    token_url = reverse('token')
+    post_data = {
+        'client_id': oidc_client.client_id,
+        'grant_type': 'authorization_code',
+        'redirect_uri': 'https://tunnistamo.test/redirect_uri',
+        'code': code.code,
+        'scope': 'openid',
+    }
+    token_response = client.post(token_url, post_data)
+
+    assert token_response.status_code == 200
+
+    id_token_string = token_response.json().get("id_token")
+    id_token_data = jwt.decode(id_token_string, verify=False)
+
+    assert id_token_data.get("loa") == expected_loa_value

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -144,7 +144,7 @@ def test_implicit_oidc_login_id_token_content(
 
     expected_keys = {
         'aud', 'sub', 'exp', 'iat', 'iss',  'nonce',
-        'at_hash', 'auth_time',
+        'at_hash', 'auth_time', 'azp', 'loa'
     } | ({
         'name', 'family_name', 'given_name', 'nickname',
     } if 'profile' in scope else set()) | ({


### PR DESCRIPTION
The azp claim is simply the current clients client_id. The loa claim is relayed from the HelsinkiTunnistus backend. (i.e. Helsinki Tunnistus Keycloak)

As the OIDC provider and the social auth backends are not connected, the loa value is saved to the users session in the social auth pipeline when the user returns from the HelsinkiTunnistus backend. Afterwards when creating the OIDC tokens, the session value is read and added as "loa" claim. The default value for the "loa" claim is "low".

Refs HP-437