### PR TITLE
Relay client_id from the OIDC provider to the HelsinkiTunnistus backend

### DIFF
--- a/auth_backends/helsinki_tunnistus_suomifi.py
+++ b/auth_backends/helsinki_tunnistus_suomifi.py
@@ -16,3 +16,19 @@ class HelsinkiTunnistus(OpenIdConnectAuth):
         # We explicitly want to use the UUID from the keycloak provided
         # token as our own identity
         return self.get_user_id(details, response)
+
+    def auth_extra_arguments(self):
+        extra_arguments = super().auth_extra_arguments()
+
+        # Set the original_client_id GET parameter into the authentication url
+        # if this authentication is the result of the OIDC provider.
+        #
+        # This is done to relay the client_id to the Helsinki tunnistus Keycloak.
+        # The session variable is set in the TunnistamoOidcAuthorizeView.get method.
+        original_client_id = self.strategy.request.session.get(
+            "oidc_authorize_original_client_id"
+        )
+        if original_client_id:
+            extra_arguments["original_client_id"] = original_client_id
+
+        return extra_arguments

--- a/users/views.py
+++ b/users/views.py
@@ -123,6 +123,19 @@ class AuthenticationErrorView(TemplateView):
 class TunnistamoOidcAuthorizeView(AuthorizeView):
     def get(self, request, *args, **kwargs):
         request.GET = _extend_scope_in_query_params(request.GET)
+
+        if request.GET.get('client_id'):
+            try:
+                client = Client.objects.get(client_id=request.GET.get('client_id'))
+
+                # Save the client_id to the session to be used in the HelsinkiTunnistus
+                # social auth backend.
+                request.session["oidc_authorize_original_client_id"] = client.client_id
+            except Client.DoesNotExist:
+                # We don't care if the client wasn't found because the client will be
+                # validated again in the parent get method.
+                pass
+
         request_locales = [l.strip() for l in request.GET.get('ui_locales', '').split(' ') if l]
         available_locales = [l[0] for l in settings.LANGUAGES]
 


### PR DESCRIPTION
Save the users client_id in the OIDC authorize view to be added later as an extra parameter when the user moves to authenticate with the HelsinkiTunnistus Keycloak.

Notice that the original_client_id is not validated in any way. (And can't be in Tunnistamo when implemented like this) That could lead the user making a service connection to a service they didn't intend to. That of course would need someone to craft a redirect url for the user and trick them somehow.

Refs HP-342