### PR TITLE
Add CORS_ALLOW_CREDENTIALS setting

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -22,6 +22,7 @@ env = environ.Env(
     ALLOWED_HOSTS=(list, []),
     ALLOW_CROSS_SITE_SESSION_COOKIE=(bool, False),
     TRUST_X_FORWARDED_HOST=(bool, False),
+    CORS_ALLOW_CREDENTIALS=(bool, False),
 
     STATIC_URL=(str, "/sso/static/"),
     STATIC_ROOT=(str, os.path.join(BASE_DIR, 'static')),
@@ -320,6 +321,7 @@ LOGGING = {
 
 CORS_ORIGIN_ALLOW_ALL = False
 CORS_URLS_REGEX = r'.*/(\.well-known/openid-configuration|v1|openid|api-tokens|jwt-token).*'
+CORS_ALLOW_CREDENTIALS = env("CORS_ALLOW_CREDENTIALS")
 
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'users.Application'


### PR DESCRIPTION
Needed to allow clients browsers to add session cookie when requesting api tokens. Which in turn is needed to read the loa value from the session when generating the api tokens.