### PR TITLE
Implement OIDC backchannel log out

### DIFF
--- a/auth_backends/backchannel_logout.py
+++ b/auth_backends/backchannel_logout.py
@@ -1,0 +1,108 @@
+import datetime
+import logging
+from calendar import timegm
+from importlib import import_module
+
+import jwt
+from django.conf import settings
+from django.contrib.auth import SESSION_KEY, get_user_model
+from django.utils import timezone
+from jose import jwk
+from jose.jwt import ExpiredSignatureError, JWTClaimsError, JWTError
+from social_core.exceptions import AuthException, AuthTokenError
+
+logger = logging.getLogger(__name__)
+
+
+class OidcBackchannelLogoutMixin:
+    def validate_logout_claims(self, logout_token):
+        utc_timestamp = timegm(datetime.datetime.utcnow().utctimetuple())
+
+        if self.id_token_issuer() != logout_token.get('iss'):
+            raise AuthTokenError(self, 'Incorrect logout_token: iss')
+
+        # Verify the token was issued in the last ID_TOKEN_MAX_AGE seconds
+        iat_leeway = self.setting('ID_TOKEN_MAX_AGE', self.ID_TOKEN_MAX_AGE)
+        if utc_timestamp > logout_token.get('iat') + iat_leeway:
+            raise AuthTokenError(self, 'Incorrect logout_token: iat')
+
+        if not logout_token.get('sub'):
+            raise AuthTokenError(self, 'Incorrect logout_token: sub')
+
+        events = logout_token.get('events')
+        try:
+            if not events or 'http://schemas.openid.net/event/backchannel-logout' not in events.keys():
+                raise AuthTokenError(self, 'Incorrect logout_token: events')
+        except AttributeError:
+            raise AuthTokenError(self, 'Incorrect logout_token: events')
+
+        if logout_token.get('nonce'):
+            raise AuthTokenError(self, 'Incorrect logout_token: nonce')
+
+    def validate_and_return_logout_token(self, logout_token):
+        """
+        Validates the logout_token according to the steps at
+        https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation.
+        """
+        client_id, client_secret = self.get_key_and_secret()
+
+        try:
+            key = self.find_valid_key(logout_token)
+        except ValueError:
+            raise AuthTokenError(self, 'Incorrect logout_token: key missing')
+
+        if not key:
+            raise AuthTokenError(self, 'Signature verification failed')
+
+        alg = key['alg']
+        rsa_key = jwk.construct(key)
+
+        try:
+            claims = jwt.decode(
+                logout_token,
+                rsa_key.to_pem().decode('utf-8'),
+                algorithms=[alg],
+                audience=client_id,
+                options=self.JWT_DECODE_OPTIONS,
+            )
+        except ExpiredSignatureError:
+            raise AuthTokenError(self, 'Signature has expired')
+        except JWTClaimsError as error:
+            raise AuthTokenError(self, str(error))
+        except JWTError:
+            raise AuthTokenError(self, 'Invalid signature')
+
+        self.validate_logout_claims(claims)
+
+        return claims
+
+    def backchannel_logout(self, *args, **kwargs):
+        post_data = self.strategy.request_post()
+
+        logout_token = post_data.get('logout_token')
+        if not logout_token:
+            raise AuthException(self, 'Log out token missing')
+
+        claims = self.validate_and_return_logout_token(logout_token)
+
+        social_auth = self.strategy.storage.user.get_social_auth(
+            self.name,
+            claims.get('sub'),
+        )
+        if not social_auth:
+            raise AuthException(self, 'User not authenticated with this backend')
+
+        # Notice: The following is a Django specific session deletion
+        User = get_user_model()  # noqa
+        SessionStore = import_module(settings.SESSION_ENGINE).SessionStore  # noqa
+        Session = SessionStore.get_model_class()  # noqa
+
+        sessions = Session.objects.filter(expire_date__gte=timezone.now())
+        for session in sessions:
+            session_data = session.get_decoded()
+            session_user_id = User._meta.pk.to_python(session_data.get(SESSION_KEY))
+            if session_user_id != social_auth.user.id:
+                continue
+
+            logger.info(f'Deleted a session for user {session_user_id}')
+            session.delete()

--- a/auth_backends/helsinki_tunnistus_suomifi.py
+++ b/auth_backends/helsinki_tunnistus_suomifi.py
@@ -1,7 +1,9 @@
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 
+from auth_backends.backchannel_logout import OidcBackchannelLogoutMixin
 
-class HelsinkiTunnistus(OpenIdConnectAuth):
+
+class HelsinkiTunnistus(OidcBackchannelLogoutMixin, OpenIdConnectAuth):
     """Authenticates the user against Keycloak proxying to suomi.fi
        This is plain OIDC backend, except that it uses the Keycloak provided
        user id ("sub" field) as the local user identifier.

--- a/auth_backends/tests/conftest.py
+++ b/auth_backends/tests/conftest.py
@@ -1,0 +1,91 @@
+import time
+
+import pytest
+from Cryptodome.PublicKey import RSA
+from Cryptodome.PublicKey.RSA import importKey
+from django.utils.crypto import get_random_string
+from jwkest import long_to_base64
+from jwkest.jwk import RSAKey as jwk_RSAKey
+from jwkest.jws import JWS
+from oidc_provider.models import RSAKey
+from social_django.models import DjangoStorage
+
+from auth_backends.backchannel_logout import OidcBackchannelLogoutMixin
+from tunnistamo.tests.conftest import rsa_key  # noqa: F401
+from users.tests.conftest import (  # noqa: F401
+    DummyOidcBackend, DummyOidcBackendBase, application_factory, user_factory, usersocialauth_factory
+)
+
+
+@pytest.fixture
+def django_client_factory():
+    def make_instance(**args):
+        from django.test.client import Client
+        return Client(**args)
+
+    return make_instance
+
+
+class DummyOidcBackchannelLogoutBackend(
+    OidcBackchannelLogoutMixin,
+    DummyOidcBackendBase
+):
+    name = 'dummyoidclogoutbackend'
+
+    def get_jwks_keys(self):
+        dic = dict(keys=[])
+
+        for rsakey in RSAKey.objects.all():
+            public_key = RSA.importKey(rsakey.key).publickey()
+            dic['keys'].append({
+                'kty': 'RSA',
+                'alg': 'RS256',
+                'use': 'sig',
+                'kid': rsakey.kid,
+                'n': long_to_base64(public_key.n),
+                'e': long_to_base64(public_key.e),
+            })
+
+        return dic['keys']
+
+
+@pytest.fixture
+def logout_token_factory():
+    def make_instance(backend, **args):
+        args.setdefault('iss', backend.oidc_config().get('issuer'))
+        args.setdefault('sub', get_random_string())
+        args.setdefault('aud', backend.setting('KEY'))
+        args.setdefault('iat', int(time.time()) + 60 * 60)
+        args.setdefault('jti', get_random_string())
+        args.setdefault(
+            'events',
+            {
+                'http://schemas.openid.net/event/backchannel-logout': {},
+            }
+        )
+
+        keys = []
+        for rsakey in RSAKey.objects.all():
+            keys.append(jwk_RSAKey(key=importKey(rsakey.key), kid=rsakey.kid))
+
+        _jws = JWS(args, alg='RS256')
+        return _jws.sign_compact(keys)
+
+    return make_instance
+
+
+class DummyStrategy:
+    def __init__(self):
+        self.logout_token = None
+        self.storage = DjangoStorage
+
+    def setting(self, key, default=None, backend=None):
+        if key == 'KEY':
+            return 'dummykey'
+        if key == 'ID_TOKEN_MAX_AGE':
+            return 60
+
+    def request_post(self):
+        return {
+            'logout_token': self.logout_token
+        }

--- a/auth_backends/tests/test_oidc_backchannel_logout.py
+++ b/auth_backends/tests/test_oidc_backchannel_logout.py
@@ -1,0 +1,299 @@
+import logging
+import time
+
+import pytest
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+from jwt import InvalidAudienceError
+from social_core.exceptions import AuthException, AuthTokenError
+
+from .conftest import DummyOidcBackchannelLogoutBackend, DummyOidcBackend, DummyStrategy
+
+
+@pytest.mark.django_db
+def test_logout_token_invalid_issuer(
+    rsa_key,
+    logout_token_factory,
+):
+    backend = DummyOidcBackchannelLogoutBackend()
+    backend.strategy = DummyStrategy()
+
+    logout_token = logout_token_factory(
+        backend,
+        iss='invalid_issuer',
+    )
+    backend.strategy.logout_token = logout_token
+
+    with pytest.raises(AuthTokenError) as excinfo:
+        backend.backchannel_logout()
+
+    assert 'Incorrect logout_token: iss' in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_logout_token_invalid_audience(
+    rsa_key,
+    logout_token_factory,
+):
+    backend = DummyOidcBackchannelLogoutBackend()
+    backend.strategy = DummyStrategy()
+
+    logout_token = logout_token_factory(
+        backend,
+        aud='invalid_audience',
+    )
+    backend.strategy.logout_token = logout_token
+
+    with pytest.raises(InvalidAudienceError) as excinfo:
+        backend.backchannel_logout()
+
+    assert 'Invalid audience' in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_logout_token_invalid_events(
+    rsa_key,
+    logout_token_factory,
+):
+    backend = DummyOidcBackchannelLogoutBackend()
+    backend.strategy = DummyStrategy()
+
+    logout_token = logout_token_factory(
+        backend,
+        events={'invalid event': {}}
+    )
+    backend.strategy.logout_token = logout_token
+
+    with pytest.raises(AuthTokenError) as excinfo:
+        backend.backchannel_logout()
+
+    assert 'Incorrect logout_token: events' in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_logout_token_invalid_issued_at_time(
+    rsa_key,
+    logout_token_factory,
+):
+    backend = DummyOidcBackchannelLogoutBackend()
+    backend.strategy = DummyStrategy()
+
+    logout_token = logout_token_factory(
+        backend,
+        iat=int(time.time()) - 60*60*24*2  # Two days ago
+    )
+    backend.strategy.logout_token = logout_token
+
+    with pytest.raises(AuthTokenError) as excinfo:
+        backend.backchannel_logout()
+
+    assert 'Incorrect logout_token: iat' in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_logout_token_invalid_subject(
+    rsa_key,
+    logout_token_factory,
+):
+    backend = DummyOidcBackchannelLogoutBackend()
+    backend.strategy = DummyStrategy()
+
+    logout_token = logout_token_factory(
+        backend,
+        sub='',
+    )
+    backend.strategy.logout_token = logout_token
+
+    with pytest.raises(AuthTokenError) as excinfo:
+        backend.backchannel_logout()
+
+    assert 'Incorrect logout_token: sub' in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_logout_token_extra_nonce(
+    rsa_key,
+    logout_token_factory,
+):
+    backend = DummyOidcBackchannelLogoutBackend()
+    backend.strategy = DummyStrategy()
+
+    logout_token = logout_token_factory(
+        backend,
+        nonce=get_random_string(),
+    )
+    backend.strategy.logout_token = logout_token
+
+    with pytest.raises(AuthTokenError) as excinfo:
+        backend.backchannel_logout()
+
+    assert 'Incorrect logout_token: nonce' in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_logout_token_no_social_auth(
+    rsa_key,
+    logout_token_factory,
+):
+    backend = DummyOidcBackchannelLogoutBackend()
+    backend.strategy = DummyStrategy()
+
+    logout_token = logout_token_factory(
+        backend,
+        sub=get_random_string(),
+    )
+    backend.strategy.logout_token = logout_token
+
+    with pytest.raises(AuthException) as excinfo:
+        backend.backchannel_logout()
+
+    assert 'User not authenticated with this backend' in str(excinfo.value)
+
+
+@pytest.mark.django_db
+def test_backchannel_logout_not_implemented(
+    settings,
+    django_client_factory,
+    application_factory,
+    user_factory,
+    usersocialauth_factory,
+):
+    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
+        'auth_backends.tests.conftest.DummyOidcBackend',
+    )
+
+    # We need to reload the social_django.utils module because the social auth
+    # AUTHENTICATION_BACKENDS setting is read when the utils module is loaded.
+    import social_django.utils
+    from importlib import reload
+    reload(social_django.utils)
+
+    password = get_random_string()
+    user = user_factory(password=password)
+    usersocialauth_factory(provider='dummyoidcbackend', user=user)
+
+    user_django_client = django_client_factory()
+    user_django_client.login(username=user.username, password=password)
+
+    op_django_client = django_client_factory()
+    backchannel_logout_url = reverse(
+        'auth_backends:backchannel_logout',
+        kwargs={'backend': DummyOidcBackend.name}
+    )
+    logout_response = op_django_client.post(backchannel_logout_url)
+    assert logout_response.status_code == 500
+
+    response = user_django_client.get('/accounts/profile/')
+
+    assert response.status_code == 200
+    assert str(user) in str(response.content)
+    assert response.wsgi_request.user.is_authenticated is True
+
+
+@pytest.mark.django_db
+def test_backchannel_successful_logout(
+    caplog,
+    rsa_key,
+    settings,
+    django_client_factory,
+    user_factory,
+    usersocialauth_factory,
+    logout_token_factory,
+):
+    caplog.set_level(logging.INFO)
+
+    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
+        'auth_backends.tests.conftest.DummyOidcBackchannelLogoutBackend',
+    )
+    settings.SOCIAL_AUTH_DUMMYOIDCLOGOUTBACKEND_KEY = 'dummykey'
+
+    # We need to reload the social_django.utils module because the social auth
+    # AUTHENTICATION_BACKENDS setting is read when the utils module is loaded.
+    import social_django.utils
+    from importlib import reload
+    reload(social_django.utils)
+
+    password = get_random_string()
+    user = user_factory(password=password)
+
+    backend = DummyOidcBackchannelLogoutBackend()
+    social_auth = usersocialauth_factory(provider=backend.name, user=user)
+
+    user_django_client = django_client_factory()
+    user_django_client.login(username=user.username, password=password)
+
+    op_django_client = django_client_factory()
+    backchannel_logout_url = reverse(
+        'auth_backends:backchannel_logout',
+        kwargs={'backend': backend.name}
+    )
+
+    logout_token = logout_token_factory(backend, sub=social_auth.uid)
+
+    data = {
+        'logout_token': logout_token
+    }
+    logout_response = op_django_client.post(backchannel_logout_url, data=data)
+
+    assert logout_response.status_code == 200
+    assert (
+               'auth_backends.backchannel_logout',
+               20,
+               f'Deleted a session for user {user.pk}'
+           ) in caplog.record_tuples
+
+    response = user_django_client.get('/accounts/profile/')
+
+    assert response.status_code == 200
+    assert str(user) not in str(response.content)
+    assert response.wsgi_request.user.is_authenticated is False
+
+
+@pytest.mark.django_db
+def test_backchannel_logout_no_social_auth(
+    rsa_key,
+    settings,
+    django_client_factory,
+    user_factory,
+    usersocialauth_factory,
+    logout_token_factory,
+):
+    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
+        'auth_backends.tests.conftest.DummyOidcBackchannelLogoutBackend',
+    )
+    settings.SOCIAL_AUTH_DUMMYOIDCLOGOUTBACKEND_KEY = 'dummykey'
+
+    # We need to reload the social_django.utils module because the social auth
+    # AUTHENTICATION_BACKENDS setting is read when the utils module is loaded.
+    import social_django.utils
+    from importlib import reload
+    reload(social_django.utils)
+
+    password = get_random_string()
+    user = user_factory(password=password)
+
+    backend = DummyOidcBackchannelLogoutBackend()
+
+    user_django_client = django_client_factory()
+    user_django_client.login(username=user.username, password=password)
+
+    op_django_client = django_client_factory()
+    backchannel_logout_url = reverse(
+        'auth_backends:backchannel_logout',
+        kwargs={'backend': backend.name}
+    )
+
+    logout_token = logout_token_factory(backend, sub=str(user.uuid))
+
+    data = {
+        'logout_token': logout_token
+    }
+    logout_response = op_django_client.post(backchannel_logout_url, data=data)
+
+    assert logout_response.status_code == 400
+
+    response = user_django_client.get('/accounts/profile/')
+
+    assert response.status_code == 200
+    assert str(user) in str(response.content)
+    assert response.wsgi_request.user.is_authenticated is True

--- a/auth_backends/urls.py
+++ b/auth_backends/urls.py
@@ -8,4 +8,6 @@ urlpatterns = [
     # Suomi.fi specific endpoints
     re_path(r'^suomifi/logout/callback/$', views.suomifi_logout_view, name='suomifi_logout_callback'),
     re_path(r'^suomifi/metadata/$', views.suomifi_metadata_view, name='suomifi_metadata'),
+    # Backchannel log out
+    re_path(r'^backchannel_logout/(?P<backend>[^/]+)/$', views.backchannel_logout, name='backchannel_logout'),
 ]

--- a/auth_backends/views.py
+++ b/auth_backends/views.py
@@ -1,7 +1,15 @@
+import logging
+
 from django.conf import settings
 from django.http import HttpResponse
 from django.urls import reverse
-from social_django.utils import load_backend, load_strategy
+from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from social_core.exceptions import AuthException
+from social_django.utils import load_backend, load_strategy, psa
+
+logger = logging.getLogger(__name__)
 
 
 def suomifi_metadata_view(request):
@@ -23,3 +31,26 @@ def suomifi_logout_view(request, uuid=None):
         redirect_uri=getattr(settings, 'LOGIN_URL'),
     )
     return saml_backend.process_logout_message()
+
+
+@require_POST
+@never_cache
+@csrf_exempt
+@psa()
+def backchannel_logout(request, backend=None):
+    try:
+        if not hasattr(request.backend, 'backchannel_logout'):
+            message = 'Backchannel logout is not implemented for backend "{}" '.format(
+                request.backend.name
+            )
+            logger.warning(message)
+
+            return HttpResponse(message, status=500)
+
+        logger.info(f'Starting backchannel logout for backend "{request.backend.name}"')
+        request.backend.backchannel_logout()
+
+        return request.backend.strategy.html('')
+    except AuthException as e:
+        logger.warning(f'Error in backchannel logout for backend "{request.backend.name}": {str(e)}')
+        return HttpResponse(str(e), status=400)


### PR DESCRIPTION
Backchannel log out is a call that an OIDC IDP can make on behalf of the user if the IDP is configured to log the user out from its clients. The user doesn't themselves access the log out endpoint. The OIDC backchannel logout is specified here: [https://openid.net/specs/openid-connect-backchannel-1_0.html](https://openid.net/specs/openid-connect-backchannel-1_0.html)

After the IDP has made a POST request to the backchannel log out endpoint the log out token is verified and if the user has logged in using the backend, all of the users non-expired Django sessions are deleted. Thus logging the user out of Tunnistamo.

All of the users sessions are deleted because there is no link between social authentications and sessions.

The implementation is modeled after the other views and methods in the social core. The backchannel log out is not enabled for all OIDC backends, but the backend class must inherit `OidcBackchannelLogoutMixin` class first. In this pull requst the `HelsinkiTunnistus` backend is changed to inherit from the mixin.

Refs HP-470
Refs HP-448
