### PR TITLE
Get loa claim value from the ID Token instead of the session

### DIFF
--- a/oidc_apis/api_tokens.py
+++ b/oidc_apis/api_tokens.py
@@ -48,6 +48,7 @@ def generate_api_token(api_scopes, token, request=None):
     payload.update(id_token)
     payload.update(_get_api_authorization_claims(api_scopes))
     payload['exp'] = _get_api_token_expires_at(token)
+    payload['loa'] = _get_api_token_level_of_assurance(token)
 
     return encode_id_token(payload, api.oidc_client)
 
@@ -73,3 +74,11 @@ def _datetime_to_timestamp(dt):
 
 
 _EPOCH = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
+
+
+def _get_api_token_level_of_assurance(token):
+    loa = "low"
+    if token.id_token and token.id_token.get('loa'):
+        return token.id_token.get('loa')
+
+    return loa

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -22,7 +22,6 @@ env = environ.Env(
     ALLOWED_HOSTS=(list, []),
     ALLOW_CROSS_SITE_SESSION_COOKIE=(bool, False),
     TRUST_X_FORWARDED_HOST=(bool, False),
-    CORS_ALLOW_CREDENTIALS=(bool, False),
 
     STATIC_URL=(str, "/sso/static/"),
     STATIC_ROOT=(str, os.path.join(BASE_DIR, 'static')),
@@ -321,7 +320,6 @@ LOGGING = {
 
 CORS_ORIGIN_ALLOW_ALL = False
 CORS_URLS_REGEX = r'.*/(\.well-known/openid-configuration|v1|openid|api-tokens|jwt-token).*'
-CORS_ALLOW_CREDENTIALS = env("CORS_ALLOW_CREDENTIALS")
 
 
 OAUTH2_PROVIDER_APPLICATION_MODEL = 'users.Application'

--- a/tunnistamo/tests/conftest.py
+++ b/tunnistamo/tests/conftest.py
@@ -2,8 +2,10 @@ import datetime
 
 import pytest
 from django.utils import timezone
+from django.utils.crypto import get_random_string
 from oidc_provider.models import Code
 
+from oidc_apis.models import Api, ApiDomain, ApiScope
 from users.tests.conftest import loginmethod_factory, oidcclient_factory, user  # noqa
 
 
@@ -29,6 +31,45 @@ def oidc_code_factory():
         args.setdefault("is_authentication", True)
 
         instance = Code.objects.create(**args)
+
+        return instance
+
+    return make_instance
+
+
+@pytest.fixture()
+def api_scope_factory():
+    def make_instance(**args):
+        args.setdefault('name', get_random_string())
+        args.setdefault('description', get_random_string())
+
+        instance = ApiScope.objects.create(**args)
+        instance.identifier = instance._generate_identifier()
+        instance.save()
+
+        return instance
+
+    return make_instance
+
+
+@pytest.fixture()
+def api_factory():
+    def make_instance(**args):
+        args.setdefault('name', get_random_string())
+
+        instance = Api.objects.create(**args)
+
+        return instance
+
+    return make_instance
+
+
+@pytest.fixture()
+def api_domain_factory():
+    def make_instance(**args):
+        args.setdefault('identifier', get_random_string())
+
+        instance = ApiDomain.objects.create(**args)
 
         return instance
 

--- a/tunnistamo/tests/test_azp_and_loa.py
+++ b/tunnistamo/tests/test_azp_and_loa.py
@@ -2,6 +2,8 @@ import jwt
 import pytest
 from django.urls import reverse
 
+from oidc_apis.views import get_api_tokens_view
+
 
 @pytest.mark.django_db
 def test_id_token_has_azp_claim(
@@ -89,3 +91,104 @@ def test_id_token_has_loa_claim_from_session(
     id_token_data = jwt.decode(id_token_string, verify=False)
 
     assert id_token_data.get("loa") == expected_loa_value
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'session_loa_value,expected_loa_value',
+    [
+        (None, "low"),
+        ("low", "low"),
+        ("substantial", "substantial"),
+        ("abcdefg", "abcdefg"),
+    ]
+)
+def test_api_token_has_loa_claim(
+    user,
+    client,
+    oidcclient_factory,
+    rsa_key,
+    oidc_code_factory,
+    api_domain_factory,
+    api_factory,
+    api_scope_factory,
+    session_loa_value,
+    expected_loa_value,
+):
+    oidc_client = oidcclient_factory(
+        client_id="https://tunnistamo.test/test_client",
+        redirect_uris=['https://tunnistamo.test/redirect_uri'],
+        response_types=["id_token"]
+    )
+
+    api_domain = api_domain_factory(identifier='https://tunnistamo.test/')
+
+    api_oidc_client = oidcclient_factory(
+        client_id="https://tunnistamo.test/test_api",
+        redirect_uris=['https://tunnistamo.test/redirect_uri'],
+        response_types=["id_token"]
+    )
+
+    api = api_factory(
+        name="test_api",
+        domain=api_domain,
+        oidc_client=api_oidc_client,
+    )
+    api_scope = api_scope_factory(api=api)
+    api_scope.allowed_apps.set([oidc_client])
+
+    code = oidc_code_factory(
+        user=user,
+        client=oidc_client,
+        scope=['openid', api_scope.identifier]
+    )
+
+    if session_loa_value:
+        session = client.session
+        session["heltunnistussuomifi_loa"] = session_loa_value
+        session.save()
+
+    # Get id token
+    token_url = reverse('token')
+    post_data = {
+        'client_id': oidc_client.client_id,
+        'grant_type': 'authorization_code',
+        'redirect_uri': 'https://tunnistamo.test/redirect_uri',
+        'code': code.code,
+        'scope': 'openid',
+    }
+    token_response = client.post(token_url, post_data)
+
+    assert token_response.status_code == 200
+
+    id_token_string = token_response.json().get('id_token')
+    id_token_data = jwt.decode(id_token_string, verify=False)
+
+    assert id_token_data.get("loa") == expected_loa_value
+
+    # Get API tokens using the client with the session id cookie
+    access_token = token_response.json().get('access_token')
+
+    api_token_url = reverse(get_api_tokens_view)
+    api_token_response = client.get(
+        api_token_url,
+        HTTP_AUTHORIZATION='Bearer {}'.format(access_token)
+    )
+
+    api_token_string = api_token_response.json().get(api.identifier)
+    api_token_data = jwt.decode(api_token_string, verify=False)
+    assert api_token_data.get("loa") == expected_loa_value
+
+    # Delete cookies from the client
+    session = client.session
+    session.flush()
+
+    # Get API tokens without cookies
+    api_token_response = client.get(
+        api_token_url,
+        HTTP_AUTHORIZATION='Bearer {}'.format(access_token)
+    )
+
+    api_token_string = api_token_response.json().get(api.identifier)
+    api_token_data = jwt.decode(api_token_string, verify=False)
+    assert api_token_data.get("loa") == expected_loa_value


### PR DESCRIPTION
The loa value is read from the session in an idtoken_processing_hook
called from create_id_token but the session is not available when API
tokens are requested.

Refs HP-475
Refs HP-437