### PR TITLE
Add a CI GHA workflow to enable Sonarcloud integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+on:
+  # Trigger analysis when pushing in develop/master or pull requests, and when creating
+  # a pull request.
+  push:
+    branches:
+      - master
+      - develop
+  pull_request:
+      types: [opened, synchronize, reopened]
+name: CI Workflow
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        # Disabling shallow clone is recommended for improving relevancy of reporting
+        fetch-depth: 0
+    - name: SonarCloud Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Adding Sonar via GHA is required in order to properly configure the paths for the project in Sonar.