### PR TITLE
Remove access_token hiding hack from helusername backend

### DIFF
--- a/auth_backends/helsinki_username.py
+++ b/auth_backends/helsinki_username.py
@@ -9,6 +9,3 @@ class HelsinkiUsername(OpenIdConnectAuth):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.OIDC_ENDPOINT = self.setting('OIDC_ENDPOINT')
-
-    def validate_and_return_id_token(self, id_token, access_token):
-        super().validate_and_return_id_token(id_token, None)

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ django-compressor
 django-environ
 django-sass-processor
 social-auth-core[openidconnect,saml]
+python-jose>=3.2.0
 social-auth-app-django
 requests
 jwcrypto

--- a/requirements.txt
+++ b/requirements.txt
@@ -133,7 +133,7 @@ pyjwt[crypto]==1.7.1
     #   -r requirements.in
     #   django-allauth
     #   social-auth-core
-python-jose==3.0.1
+python-jose==3.2.0
     # via social-auth-core
 python3-openid==3.1.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,12 +81,10 @@ djangorestframework==3.10.2
     #   drf-oidc-auth
 drf-oidc-auth==0.9
     # via django-helusers
-ecdsa==0.15
+ecdsa==0.14.1
     # via python-jose
 future==0.16.0
-    # via
-    #   pyjwkest
-    #   python-jose
+    # via pyjwkest
 geoip2==2.9.0
     # via -r requirements.in
 idna==2.6
@@ -119,7 +117,9 @@ polib==1.1.0
 psycopg2==2.8.3
     # via -r requirements.in
 pyasn1==0.4.5
-    # via rsa
+    # via
+    #   python-jose
+    #   rsa
 pycparser==2.18
     # via cffi
 pycryptodomex==3.6.1
@@ -134,7 +134,9 @@ pyjwt[crypto]==1.7.1
     #   django-allauth
     #   social-auth-core
 python-jose==3.2.0
-    # via social-auth-core
+    # via
+    #   -r requirements.in
+    #   social-auth-core
 python3-openid==3.1.0
     # via
     #   django-allauth


### PR DESCRIPTION
Remove a hack to work around a bug in python-jose and upgrade to a fixed version of python-jose.

Keycloak 9.x issued ID-tokens without at_hash claim during authorization code flow. This caused the buggy library to reject the token. See https://github.com/mpdavis/python-jose/issues/75

Newer versions of Keycloak started to include the claim even during authorization code flow, which masked the bug.