### PR TITLE
HP-798 Allow consent skip on code flow with pkce

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ django-parler>2.1
 django-cors-headers
 # Use our own fork of django-oidc-provider as long as the token extraction PR is not merged
 # https://github.com/juanifioren/django-oidc-provider/pull/389
-git+https://github.com/City-of-Helsinki/django-oidc-provider.git@extract-token-creation
+git+https://github.com/City-of-Helsinki/django-oidc-provider.git@tunnistamo
 djangorestframework>=3.10
 pyjwt
 django-helusers

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ django-npm==1.0.0
     # via -r requirements.in
 django-oauth-toolkit==1.2.0
     # via -r requirements.in
-git+https://github.com/City-of-Helsinki/django-oidc-provider.git@extract-token-creation
+git+https://github.com/City-of-Helsinki/django-oidc-provider.git@tunnistamo
     # via -r requirements.in
 django-parler==2.2
     # via

--- a/tunnistamo/endpoints.py
+++ b/tunnistamo/endpoints.py
@@ -49,6 +49,13 @@ class TunnistamoAuthorizeEndpoint(AuthorizeEndpoint):
 
         return token
 
+    def is_client_allowed_to_skip_consent(self):
+        return (
+            self.client.client_type == 'confidential'
+            or self.grant_type == 'implicit'
+            or self.params['code_challenge'] != ''
+        )
+
 
 class TunnistamoTokenEndpoint(TokenEndpoint):
     def _get_tunnistamo_session(self):

--- a/tunnistamo/tests/test_oidc_provider_pkce.py
+++ b/tunnistamo/tests/test_oidc_provider_pkce.py
@@ -1,0 +1,68 @@
+import hashlib
+import json
+from base64 import urlsafe_b64encode
+
+import pytest
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+from oidc_provider.lib.utils.token import create_code
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('code_verifier,should_succeed', (
+    ('', False),
+    (get_random_string(), True),
+))
+def test_token_endpoint_requires_code_verifier(
+    client,
+    user,
+    rsa_key,
+    oidcclient_factory,
+    code_verifier,
+    should_succeed
+):
+    """Tests that the token endpoint really requires code_verifier
+
+    The token endpoint should validate that the code_verifier matches the code_challenge.
+    django-oidc-provider has/had a bug where a token could be acquired without
+    the code_verifier even if code_challenge was provided in the authorize call.
+
+    See https://github.com/juanifioren/django-oidc-provider/pull/361"""
+    oidc_client = oidcclient_factory(redirect_uris=['https://example.com/callback'])
+
+    nonce = get_random_string()
+    code_challenge = urlsafe_b64encode(
+        hashlib.sha256(code_verifier.encode('ascii')).digest()
+    ).decode('utf-8').replace('=', '')
+
+    code = create_code(
+        user=user,
+        client=oidc_client,
+        scope=['openid', 'email'],
+        nonce=nonce,
+        is_authentication=True,
+        code_challenge=code_challenge,
+        code_challenge_method='S256'
+    )
+    code.save()
+
+    token_url = reverse('oidc_provider:token')
+    token_request_data = {
+        'client_id': oidc_client.client_id,
+        'client_secret': oidc_client.client_secret,
+        'redirect_uri': oidc_client.redirect_uris[0],
+        'code': code.code,
+        'grant_type': 'authorization_code',
+    }
+    if code_verifier:
+        token_request_data['code_verifier'] = code_verifier
+
+    response = client.post(token_url, token_request_data, follow=False)
+    response_data = json.loads(response.content)
+
+    if should_succeed:
+        assert 'error' not in response_data
+        assert 'access_token' in response_data
+    else:
+        assert 'error' in response_data
+        assert 'access_token' not in response_data


### PR DESCRIPTION
Additionally change requirements.txt to use our own [fork and branch](https://github.com/City-of-Helsinki/django-oidc-provider/tree/tunnistamo) of the django-oidc-provider

The branch is a further branch from the develop branch and has these 
additional PRs merged to it:

- [[security] Correctly verify PKCE secret in token endpoint](https://github.com/juanifioren/django-oidc-provider/pull/361)
- [Extract token creations to their own methods](https://github.com/juanifioren/django-oidc-provider/pull/389)
- [Extract "is consent skip allowed" decision from the view to the endpoint](https://github.com/juanifioren/django-oidc-provider/pull/391)
