### PR TITLE
Add "sid" (Session ID) claim to id_token and API tokens

### DIFF
--- a/oidc_apis/utils.py
+++ b/oidc_apis/utils.py
@@ -70,6 +70,9 @@ def additional_tunnistamo_id_token_claims(dic, user, token, request, **kwargs):
     if not tunnistamo_session:
         return dic
 
+    # Add Tunnistamo Session id as the "sid" (Session ID) claim
+    dic['sid'] = str(tunnistamo_session.id)
+
     # Set the social auth backend name as the "amr" (Authentication Methods Reference)
     user_social_auth = tunnistamo_session.get_content_object_by_model(UserSocialAuth)
     if user_social_auth:

--- a/users/tests/test_models.py
+++ b/users/tests/test_models.py
@@ -144,7 +144,7 @@ def test_implicit_oidc_login_id_token_content(
 
     expected_keys = {
         'aud', 'sub', 'exp', 'iat', 'iss',  'nonce',
-        'at_hash', 'auth_time', 'azp', 'loa',
+        'at_hash', 'auth_time', 'azp', 'loa', 'sid',
     } | ({
         'name', 'family_name', 'given_name', 'nickname',
     } if 'profile' in scope else set()) | ({
@@ -169,6 +169,10 @@ def test_implicit_oidc_login_id_token_content(
     assert auth_time >= time.time() - 30
     assert abs(iat - auth_time) < 5
     assert exp == iat + 600  # ID token expires in 10 min
+
+    # Session ID
+    tunnistamo_session_id = client.session.get('tunnistamo_session_id')
+    assert id_token_data['sid'] == tunnistamo_session_id
 
     # Requested claims
     if 'profile' in scope:


### PR DESCRIPTION
The value is the ID of the current Tunnistamo Session. The "sid" claim will be used in the RPs to match sessions and logout tokens.

Refs HP-811