### PR TITLE
Redirect ADFS users to ADFS logout when logging out

### DIFF
--- a/auth_backends/adfs/helsinki.py
+++ b/auth_backends/adfs/helsinki.py
@@ -8,6 +8,7 @@ class HelsinkiADFS(BaseADFS):
     name = 'helsinki_adfs'
     AUTHORIZATION_URL = 'https://fs.hel.fi/adfs/oauth2/authorize'
     ACCESS_TOKEN_URL = 'https://fs.hel.fi/adfs/oauth2/token'
+    LOGOUT_URL = 'https://fs.hel.fi/adfs/oauth2/logout'
 
     resource = 'https://api.hel.fi/sso/adfs'
     domain_uuid = uuid.UUID('1c8974a1-1f86-41a0-85dd-94a643370621')

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -13,6 +13,7 @@ from rest_framework.test import APIClient
 from social_core.backends.open_id_connect import OpenIdConnectAuth
 from social_django.models import UserSocialAuth
 
+from auth_backends.adfs.base import BaseADFS
 from services.factories import ServiceFactory
 from users.factories import UserFactory
 from users.models import Application, LoginMethod, OidcClientOptions, TunnistamoSession
@@ -225,3 +226,10 @@ class DummyOidcBackend(DummyOidcBackendBase):
 
 class DummyOidcBackend2(DummyOidcBackendBase):
     name = 'dummyoidcbackend2'
+
+
+class DummyADFSBackend(BaseADFS):
+    name = 'dummy_adfs'
+    AUTHORIZATION_URL = 'https://dummyadfs.example.com/adfs/oauth2/authorize'
+    ACCESS_TOKEN_URL = 'https://dummyadfs.example.com/adfs/oauth2/token'
+    LOGOUT_URL = 'https://dummyadfs.example.com/adfs/oauth2/logout'


### PR DESCRIPTION
If the user used an ADFS backend as their social login, redirect them to the ADFS logout url when they are logging out of Tunnistamo. `LOGOUT_URL` is only set in the Helsinki ADFS backend for now.

Refs HP-918