### PR TITLE
Filter already deleted tokens before API backchannel logouts

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -275,7 +275,7 @@ class TunnistamoSession(models.Model):
             from oidc_apis.backchannel_logout import send_backchannel_logout_to_apis_in_token_scope
 
             tokens = [se.content_object for se in self.get_elements_by_model(Token)]
-            for token in tokens:
+            for token in filter(None, tokens):
                 send_backchannel_logout_to_apis_in_token_scope(token, request, sid=str(self.id))
 
     def has_ended(self):


### PR DESCRIPTION
The OIDC token could have been deleted by RP backchannel logout and wouldn't be found anymore. The content_object would then be None.

Refs HP-951