### PR TITLE
Improve HelsinkiTunnistus tests

### DIFF
--- a/tunnistamo/tests/test_auth_error_redirect.py
+++ b/tunnistamo/tests/test_auth_error_redirect.py
@@ -140,7 +140,7 @@ def test_on_auth_error_redirect_to_client_setting(
     on_error_redirect,
 ):
     settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
-        'tunnistamo.tests.conftest.DummyFixedOidcBackend',
+        'users.tests.conftest.DummyFixedOidcBackend',
     )
     settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_OIDC_ENDPOINT = 'https://dummy.example.com'
     settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_ON_AUTH_ERROR_REDIRECT_TO_CLIENT = on_error_redirect
@@ -176,7 +176,7 @@ def test_should_not_redirect_to_oidc_client_if_the_next_parameter_is_not_to_an_o
     on_error_redirect,
 ):
     settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
-        'tunnistamo.tests.conftest.DummyFixedOidcBackend',
+        'users.tests.conftest.DummyFixedOidcBackend',
     )
     settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_OIDC_ENDPOINT = 'https://dummy.example.com'
     settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_ON_AUTH_ERROR_REDIRECT_TO_CLIENT = on_error_redirect

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -259,10 +259,15 @@ def create_id_token(backend, **kwargs):
 
 
 class CancelExampleComRedirectClient(DjangoTestClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.intercepted_requests = []
+
     def get(self, path, data=None, follow=False, secure=False, **extra):
         # If the request is to a remote example.com address just return an empty response
         # without really making the request
         if 'example.com' in extra.get('SERVER_NAME', ''):
+            self.intercepted_requests.append({"path": path, "data": data})
             return HttpResponse()
 
         return super().get(path, data=data, follow=follow, secure=secure, **extra)


### PR DESCRIPTION
Add a new test that ensures that the `original_client_id` parameter is passed on to the Helsinki tunnistus service. As preparation some test helpers were moved to a place where they can be used from many tests. Before this new test the [HelsinkiTunnistus.auth_extra_arguments](https://github.com/City-of-Helsinki/tunnistamo/blob/d676433f63866941b8786f1f06180b7aa4087a8a/auth_backends/helsinki_tunnistus_suomifi.py#L22-L36) method wasn't covered by any tests. It was possible to remove the method and no test would fail.