### PR TITLE
Obey user's desired UI language

### DIFF
--- a/auth_backends/helsinki_tunnistus_suomifi.py
+++ b/auth_backends/helsinki_tunnistus_suomifi.py
@@ -33,6 +33,10 @@ class HelsinkiTunnistus(OidcBackchannelLogoutMixin, OpenIdConnectAuth):
         if original_client_id:
             extra_arguments["original_client_id"] = original_client_id
 
+        ui_locales = self.strategy.request.session.get("ui_locales")
+        if ui_locales:
+            extra_arguments["ui_locales"] = ui_locales
+
         return extra_arguments
 
     def get_loa(self):

--- a/tunnistamo/middleware.py
+++ b/tunnistamo/middleware.py
@@ -31,11 +31,19 @@ class LocaleMiddleware(DjangoLocaleMiddleware):
     def process_request(self, request):
         ui_locales = request.GET.get('ui_locales')
 
-        try:
-            language = translation.get_supported_language_variant(ui_locales)
+        language = None
+        if ui_locales is not None:
+            for candidate in ui_locales.split():
+                try:
+                    language = translation.get_supported_language_variant(candidate)
+                    break
+                except LookupError:
+                    pass
+
+        if language:
             translation.activate(language)
             request.LANGUAGE_CODE = translation.get_language()
-        except LookupError:
+        else:
             super().process_request(request)
 
 

--- a/tunnistamo/middleware.py
+++ b/tunnistamo/middleware.py
@@ -33,6 +33,8 @@ class LocaleMiddleware(DjangoLocaleMiddleware):
 
         language = None
         if ui_locales is not None:
+            request.session['ui_locales'] = ui_locales
+
             for candidate in ui_locales.split():
                 try:
                     language = translation.get_supported_language_variant(candidate)

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -161,7 +161,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
+    'tunnistamo.middleware.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -161,6 +161,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/tunnistamo/tests/conftest.py
+++ b/tunnistamo/tests/conftest.py
@@ -13,7 +13,7 @@ from oidc_provider.models import ResponseType
 from oidc_apis.models import Api, ApiDomain, ApiScope
 from oidc_apis.views import get_api_tokens_view
 from users.tests.conftest import (  # noqa
-    DummyFixedOidcBackend, oidcclient_factory, tunnistamosession_factory, user, usersocialauth_factory
+    DummyFixedOidcBackend, oidcclient_factory, tunnistamosession_factory, use_translations, user, usersocialauth_factory
 )
 
 

--- a/tunnistamo/tests/test_locale_middleware.py
+++ b/tunnistamo/tests/test_locale_middleware.py
@@ -1,0 +1,12 @@
+import pytest
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('lang', [None, 'fi', 'sv', 'en'])
+def test_language_is_determined_by_django_locale_middleware(lang, client, settings, use_translations):
+    headers = {'HTTP_ACCEPT_LANGUAGE': lang} if lang else {}
+    response = client.get('/login/', **headers)
+
+    expected_language = lang if lang else settings.LANGUAGE_CODE
+
+    assert f'<html lang="{expected_language}">' in response.rendered_content

--- a/tunnistamo/tests/test_locale_middleware.py
+++ b/tunnistamo/tests/test_locale_middleware.py
@@ -22,9 +22,10 @@ NON_DEFAULT_LANGUAGE_CODE = list(filter(lambda lang: lang[0] != settings.LANGUAG
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('ui_locales,expected_lang', [
-    (f'{settings.LANGUAGE_CODE}', settings.LANGUAGE_CODE),
-    (f'{NON_DEFAULT_LANGUAGE_CODE}', NON_DEFAULT_LANGUAGE_CODE),
-    (f'{NON_DEFAULT_LANGUAGE_CODE}-SPECIFIER', NON_DEFAULT_LANGUAGE_CODE),
+    (f'{settings.LANGUAGE_CODE} {NON_DEFAULT_LANGUAGE_CODE}', settings.LANGUAGE_CODE),
+    (f'{NON_DEFAULT_LANGUAGE_CODE} {settings.LANGUAGE_CODE}', NON_DEFAULT_LANGUAGE_CODE),
+    (f'{NON_DEFAULT_LANGUAGE_CODE}-SPECIFIER {settings.LANGUAGE_CODE}', NON_DEFAULT_LANGUAGE_CODE),
+    (f'de unknown  {NON_DEFAULT_LANGUAGE_CODE}  ', NON_DEFAULT_LANGUAGE_CODE),
 ])
 def test_language_is_determined_from_ui_locales_query_parameter(ui_locales, expected_lang, client, use_translations):
     data = {'ui_locales': ui_locales}

--- a/tunnistamo/tests/test_locale_middleware.py
+++ b/tunnistamo/tests/test_locale_middleware.py
@@ -1,12 +1,33 @@
 import pytest
+from django.conf import settings
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('lang', [None, 'fi', 'sv', 'en'])
-def test_language_is_determined_by_django_locale_middleware(lang, client, settings, use_translations):
+@pytest.mark.parametrize('ui_locales', [None, '', 'de'])
+def test_language_is_determined_by_django_locale_middleware_if_ui_locales_provides_no_preference(
+    lang, ui_locales, client, settings, use_translations
+):
     headers = {'HTTP_ACCEPT_LANGUAGE': lang} if lang else {}
-    response = client.get('/login/', **headers)
+    data = {'ui_locales': ui_locales} if ui_locales is not None else {}
+    response = client.get('/login/', data, **headers)
 
     expected_language = lang if lang else settings.LANGUAGE_CODE
 
     assert f'<html lang="{expected_language}">' in response.rendered_content
+
+
+NON_DEFAULT_LANGUAGE_CODE = list(filter(lambda lang: lang[0] != settings.LANGUAGE_CODE, settings.LANGUAGES))[0][0]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('ui_locales,expected_lang', [
+    (f'{settings.LANGUAGE_CODE}', settings.LANGUAGE_CODE),
+    (f'{NON_DEFAULT_LANGUAGE_CODE}', NON_DEFAULT_LANGUAGE_CODE),
+    (f'{NON_DEFAULT_LANGUAGE_CODE}-SPECIFIER', NON_DEFAULT_LANGUAGE_CODE),
+])
+def test_language_is_determined_from_ui_locales_query_parameter(ui_locales, expected_lang, client, use_translations):
+    data = {'ui_locales': ui_locales}
+    response = client.get('/login/', data)
+
+    assert f'<html lang="{expected_lang}">' in response.rendered_content

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.http import HttpResponse
 from django.test.client import Client as DjangoTestClient
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import timezone, translation
 from django.utils.crypto import get_random_string
 from httpretty import httpretty
 from jwkest import long_to_base64
@@ -27,6 +27,21 @@ from auth_backends.helsinki_tunnistus_suomifi import HelsinkiTunnistus
 from services.factories import ServiceFactory
 from users.factories import UserFactory
 from users.models import Application, LoginMethod, OidcClientOptions, TunnistamoSession
+
+
+@pytest.fixture
+def use_translations():
+    """After the test, resets the currently active translation
+    to what it was before the test. Useful when a test potentially
+    changes the current active language."""
+    language_before_the_test = translation.get_language()
+
+    yield
+
+    if language_before_the_test:
+        translation.activate(language_before_the_test)
+    else:
+        translation.deactivate()
 
 
 @pytest.fixture()

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -325,7 +325,9 @@ class DummyFixedOidcBackend(DummyOidcBackendBase):
     get_loa = HelsinkiTunnistus.get_loa
 
 
-def start_oidc_authorize(django_client, oidcclient_factory, backend_name=DummyFixedOidcBackend.name, state=None):
+def start_oidc_authorize(
+    django_client, oidcclient_factory, backend_name=DummyFixedOidcBackend.name, state=None, ui_locales=None
+):
     """Start OIDC authorization flow
 
     The client will be redirected to the Tunnistamo login view and from there to the
@@ -351,6 +353,8 @@ def start_oidc_authorize(django_client, oidcclient_factory, backend_name=DummyFi
     }
     if state:
         authorize_data['state'] = state
+    if ui_locales:
+        authorize_data['ui_locales'] = ui_locales
 
     backend = get_backend(settings.AUTHENTICATION_BACKENDS, backend_name)
     backend_oidc_config_url = backend().setting('OIDC_ENDPOINT') + '/.well-known/openid-configuration'

--- a/users/tests/test_tunnistamo_authorize_view.py
+++ b/users/tests/test_tunnistamo_authorize_view.py
@@ -27,7 +27,7 @@ def test_tunnistamo_authorize_view_is_used(client, with_trailing_slash):
     ('bogus      en fi', 'Email'),
 ))
 @pytest.mark.django_db
-def test_tunnistamo_authorize_view_language(client, ui_locales, expected_text):
+def test_tunnistamo_authorize_view_language(client, ui_locales, expected_text, use_translations):
     oidc_client = OIDCClientFactory(require_consent=True)
     user = UserFactory()
     client.force_login(user)

--- a/users/tests/test_tunnistamo_authorize_view.py
+++ b/users/tests/test_tunnistamo_authorize_view.py
@@ -156,6 +156,29 @@ def test_original_client_id_is_passed_to_helsinki_tunnistus_authentication_servi
 
 
 @pytest.mark.django_db
+def test_ui_locales_parameter_of_authorize_request_is_passed_to_helsinki_tunnistus_authentication_service(
+    settings, oidcclient_factory,
+):
+    settings.SOCIAL_AUTH_HELTUNNISTUSSUOMIFI_OIDC_ENDPOINT = 'https://heltunnistussuomifi.example.com'
+    django_client = CancelExampleComRedirectClient()
+
+    state = get_random_string()
+    ui_locales = "this can be whatever"
+    start_oidc_authorize(
+        django_client,
+        oidcclient_factory,
+        backend_name=HelsinkiTunnistus.name,
+        state=state,
+        ui_locales=ui_locales,
+    )
+
+    assert len(django_client.intercepted_requests) == 1
+    intercepted_request = django_client.intercepted_requests[0]
+    assert intercepted_request["path"] == '/authorize'
+    assert intercepted_request["data"].get("ui_locales") == ui_locales
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize('with_pkce', (True, False))
 @pytest.mark.parametrize('response_type', [key for key, val in RESPONSE_TYPE_CHOICES])
 def test_public_clients_ability_to_skip_consent(

--- a/users/views.py
+++ b/users/views.py
@@ -9,7 +9,6 @@ from django.db.models import Case, Value, When
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils import translation
 from django.utils.http import quote
 from django.views.decorators.http import require_http_methods
 from django.views.generic.base import RedirectView, TemplateView
@@ -148,14 +147,6 @@ class TunnistamoOidcAuthorizeView(AuthorizeView):
                 # We don't care if the client wasn't found because the client will be
                 # validated again in the parent get method.
                 pass
-
-        request_languages = [lang.strip() for lang in request.GET.get('ui_locales', '').split(' ') if lang]
-        available_languages = [lang[0] for lang in settings.LANGUAGES]
-
-        for lang in request_languages:
-            if lang in available_languages:
-                with translation.override(lang):
-                    return super().get(request, *args, **kwargs)
 
         return super().get(request, *args, **kwargs)
 


### PR DESCRIPTION
Take into use [Django's regular locale middleware](https://docs.djangoproject.com/en/3.2/ref/middleware/#module-django.middleware.locale) that enables showing UIs to user's in their desired language. Expand that middleware to also consider a `ui_locales` query parameter in `GET` requests. Pass the user's UI language onward to Helsinki tunnistus authorization service, again as a `ui_locales` query parameter.

**NB**: Tunnistamo's UI isn't fully localized, so you could see an unexpected language there.

**NB2**: This is now version two of this feature. The first version is still available in the [HP-904-obey-users-language-old branch](https://github.com/City-of-Helsinki/tunnistamo/tree/HP-904-obey-users-language-old) so you can compare. The differences to the first version are shortly:

- The language cookie isn't used any more. The `ui_locales` value is stored into Django session and used from there.
  - As a consequence the `ui_locales` value is now passed forward to external services as is.
- The `ui_locales` can be a space separated list of language codes in priority order. That is now handled correctly.
- Remove some view specific `ui_locales` handling as that is now covered by the common code.