### PR TITLE
Set static file serving dynamically from environment variables

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -2,8 +2,8 @@
 http-socket = :8000
 chdir = /app
 module = tunnistamo.wsgi
-static-map = /media=/app/media
-static-map = /sso/static=/var/tunnistamo/static
+static-map = $(MEDIA_URL)=$(MEDIA_ROOT)
+static-map = $(STATIC_URL)=$(STATIC_ROOT)
 uid = appuser
 gid = appuser
 buffer-size = 32768


### PR DESCRIPTION
The uWSGI configuration can use the already existing Django settings, as long as they are given as environment variables.

This uses uWSGI's [environment variable substitution feature](https://uwsgi-docs.readthedocs.io/en/latest/ParsingOrder.html#expanding-variables-placeholders).