### PR TITLE
Consider ui_locales from session for determining current language

### DIFF
--- a/tunnistamo/middleware.py
+++ b/tunnistamo/middleware.py
@@ -31,10 +31,14 @@ class LocaleMiddleware(DjangoLocaleMiddleware):
     def process_request(self, request):
         ui_locales = request.GET.get('ui_locales')
 
-        language = None
         if ui_locales is not None:
             request.session['ui_locales'] = ui_locales
+        else:
+            ui_locales = request.session.get('ui_locales')
 
+        language = None
+
+        if ui_locales:
             for candidate in ui_locales.split():
                 try:
                     language = translation.get_supported_language_variant(candidate)

--- a/tunnistamo/tests/test_locale_middleware.py
+++ b/tunnistamo/tests/test_locale_middleware.py
@@ -18,17 +18,31 @@ def test_language_is_determined_by_django_locale_middleware_if_ui_locales_provid
 
 
 NON_DEFAULT_LANGUAGE_CODE = list(filter(lambda lang: lang[0] != settings.LANGUAGE_CODE, settings.LANGUAGES))[0][0]
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('ui_locales,expected_lang', [
+UI_LOCALES_TEST_VALUES = [
     (f'{settings.LANGUAGE_CODE} {NON_DEFAULT_LANGUAGE_CODE}', settings.LANGUAGE_CODE),
     (f'{NON_DEFAULT_LANGUAGE_CODE} {settings.LANGUAGE_CODE}', NON_DEFAULT_LANGUAGE_CODE),
     (f'{NON_DEFAULT_LANGUAGE_CODE}-SPECIFIER {settings.LANGUAGE_CODE}', NON_DEFAULT_LANGUAGE_CODE),
     (f'de unknown  {NON_DEFAULT_LANGUAGE_CODE}  ', NON_DEFAULT_LANGUAGE_CODE),
-])
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('ui_locales,expected_lang', UI_LOCALES_TEST_VALUES)
 def test_language_is_determined_from_ui_locales_query_parameter(ui_locales, expected_lang, client, use_translations):
     data = {'ui_locales': ui_locales}
     response = client.get('/login/', data)
+
+    assert f'<html lang="{expected_lang}">' in response.rendered_content
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('ui_locales,expected_lang', UI_LOCALES_TEST_VALUES)
+def test_ui_locales_is_remembered_and_used_during_a_session(ui_locales, expected_lang, client, use_translations):
+    # Stores the ui_locales into the session
+    data = {'ui_locales': ui_locales}
+    client.get('/login/', data)
+
+    # Uses the ui_locales from the session
+    response = client.get('/login/')
 
     assert f'<html lang="{expected_lang}">' in response.rendered_content


### PR DESCRIPTION
The `ui_locales` value was already stored in the session. But it was not used for determining the user's desired language during that session. This commit adds that.

The language determination logic is now thus:
- Use `ui_locales` query parameter
- Use `ui_locales` stored in session (added in this commit)
- Use the default Django locale middleware's functionality

The use case for this is the following. A user wants to authenticate. They enter the `/openid/authorize` endpoint, providing their desired language with a `ui_locales` query parameter. Tunnistamo responds with a 302 code and redirects the client to the `/login` page. This login page should be shown with the language the user desired. Before this PR this didn't happen.