### PR TITLE
Add ability to give command line arguments to uwsgi

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -92,5 +92,5 @@ if [[ ! -z "$@" ]]; then
 elif [[ "$DEV_SERVER" = "1" ]]; then
     python ./manage.py runserver 0.0.0.0:8000
 else
-    uwsgi --ini .prod/uwsgi.ini
+    uwsgi --ini .prod/uwsgi.ini $ARGS_UWSGI
 fi


### PR DESCRIPTION
**Edit**: #194 was chosen instead of this PR.

Extra command line arguments can be given with `$ARGS_UWSGI` environment variable. The name is chosen like this because uwsgi itself uses environment variables starting with `UWSGI_`.

This feature would make #194 obsolete as that, and much more, can be achieved with this more general solution.