### PR TITLE
Support sub-path serving in the Docker image

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -1,7 +1,8 @@
 [uwsgi]
 http-socket = :8000
 chdir = /app
-module = tunnistamo.wsgi
+mount = $(APP_URL_PATH)=tunnistamo/wsgi.py
+manage-script-name = true
 static-map = $(MEDIA_URL)=$(MEDIA_ROOT)
 static-map = $(STATIC_URL)=$(STATIC_ROOT)
 uid = appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ ENTRYPOINT ["./docker-entrypoint.sh"]
 # STore static files under /var to not conflict with development volume mount
 ENV STATIC_ROOT /var/tunnistamo/static
 ENV NODE_MODULES_ROOT /var/tunnistamo/node_modules
+ENV APP_URL_PATH /
 COPY --from=staticbuilder --chown=appuser:appuser /app/static /var/tunnistamo/static
 COPY --from=staticbuilder --chown=appuser:appuser /app/node_modules /var/tunnistamo/node_modules
 


### PR DESCRIPTION
Use uWSGI "mount"-mechanism to support serving tunnistamo from paths other than root.