### PR TITLE
Don't use random strings in test parametrization

### DIFF
--- a/tunnistamo/tests/test_oidc_provider_pkce.py
+++ b/tunnistamo/tests/test_oidc_provider_pkce.py
@@ -11,7 +11,7 @@ from oidc_provider.lib.utils.token import create_code
 @pytest.mark.django_db
 @pytest.mark.parametrize('code_verifier,should_succeed', (
     ('', False),
-    (get_random_string(), True),
+    pytest.param(get_random_string(), True, id='random_string'),
 ))
 def test_token_endpoint_requires_code_verifier(
     client,

--- a/users/tests/test_logout_view.py
+++ b/users/tests/test_logout_view.py
@@ -54,7 +54,7 @@ def test_logout_redirect_next(client, user_factory, _next, expected, application
 @pytest.mark.parametrize('_next', (
     None,
     '',
-    get_random_string(),
+    pytest.param(get_random_string(), id='random_string'),
     12345,
     '//example.com',
     '/foo',


### PR DESCRIPTION
The full test names generated by Pytest, which include the parameter values, change all the time if the parameters are random. That can e.g. mess up IDEs as they have hard time keeping track what are the tests' names.