### PR TITLE
Add a default for MEDIA_ROOT (/var/tunnistamo/media)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # STore static files under /var to not conflict with development volume mount
 ENV STATIC_ROOT /var/tunnistamo/static
+ENV MEDIA_ROOT /var/tunnistamo/media
 ENV NODE_MODULES_ROOT /var/tunnistamo/node_modules
 ENV APP_URL_PATH /
 COPY --from=staticbuilder --chown=appuser:appuser /app/static /var/tunnistamo/static


### PR DESCRIPTION
Tunnistamo only uses Django media for the, unused in Helsinki,
services application. Still, setting a default path for media
files inside the container image seems safer than leaving it empty.

The path is not created in Dockerfile, so user needs to explicitly
mount something there for uploads to work.