### PR TITLE
Make STATIC_URL & MEDIA_URL work in container

### DIFF
--- a/.prod/uwsgi.ini
+++ b/.prod/uwsgi.ini
@@ -3,8 +3,8 @@ http-socket = :8000
 chdir = /app
 mount = $(APP_URL_PATH)=tunnistamo/wsgi.py
 manage-script-name = true
-static-map = $(MEDIA_URL)=$(MEDIA_ROOT)
-static-map = $(STATIC_URL)=$(STATIC_ROOT)
+static-map = $(MEDIA_URL_ROOTLESS)=$(MEDIA_ROOT)
+static-map = $(STATIC_URL_ROOTLESS)=$(STATIC_ROOT)
 uid = appuser
 gid = appuser
 buffer-size = 32768


### PR DESCRIPTION
As it turns out uWSGI has interaction with mount-mechanism and static-map mechanism. With following configuration:

> mount = /sso-test=tunnistamo/wsgi.py
> static-map = /static=/var/tunnistamo/static

The file
`/var/tunnistamo/static/css/helsinki_theme.css`
will be available at URL
`https://hostname/sso-test/static/css/helsinki_theme.css`

So this means that uWSGI needs to be told to serve `/static` and Django needs to be told to generate URLs to `/sso-test/static/`. This PR attempts to that.