### PR TITLE
Fix SESSION_COOKIE_SAMESITE setting value

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -373,7 +373,7 @@ SESSION_COOKIE_SECURE = env('COOKIE_SECURE')
 # using IFRAME.
 if env('ALLOW_CROSS_SITE_SESSION_COOKIE'):
     # Not setting the attribute allows cookies to be passed across sites
-    SESSION_COOKIE_SAMESITE = None
+    SESSION_COOKIE_SAMESITE = 'None'
 
 USE_X_FORWARDED_HOST = env("TRUST_X_FORWARDED_HOST")
 


### PR DESCRIPTION
Setting ALLOW_CROSS_SITE_SESSION_COOKIE as True should make Tunnistamo
emit session cookies with "SameSite" as "None" but previously the
"SameSite" was not set at all because the setting value was None.

Django sets the "SameSite" value only if the SESSION_COOKIE_SAMESITE-
setting is not falsy:

```python
if samesite:
    if samesite.lower() not in ('lax', 'none', 'strict'):
        raise ValueError('samesite must be "lax", "none", or "strict".')
    self.cookies[key]['samesite'] = samesite
```

Refs HP-1271