### PR TITLE
Lock Javascript dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 
 COPY requirements.txt /app/requirements.txt
 COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
 RUN pip install -U pip \
     && pip install --no-cache-dir  -r /app/requirements.txt
 RUN npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "tunnistamo",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bootstrap": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+    },
+    "bootstrap-sass": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz",
+      "integrity": "sha512-p5rxsK/IyEDQm2CwiHxxUi0MZZtvVFbhWmyMOt4lLkA4bujDA1TGoKT0i1FKIWiugAdP+kK8T5KMDFIKQCLYIA=="
+    },
+    "bootstrap-social": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-social/-/bootstrap-social-5.1.1.tgz",
+      "integrity": "sha1-dTDGeK31bPj60/qCwp1NPl0CdQE=",
+      "requires": {
+        "bootstrap": "~3",
+        "font-awesome": "~4.7"
+      }
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
+    "hel-bootstrap-3": {
+      "version": "1.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/hel-bootstrap-3/-/hel-bootstrap-3-1.0.0-beta.4.tgz",
+      "integrity": "sha1-38A/bmKJvbZVG5rDWvO8YL310rY=",
+      "requires": {
+        "bootstrap-sass": "^3.3.7"
+      }
+    }
+  }
+}


### PR DESCRIPTION
It's a good practice to lock dependency versions. But there's a specific reason why this needs to be done now.

Tunnistamo isn't compatible with bootstrap-sass version 3.4.2. That version switches [1] to a newish Sass syntax that isn't backwards compatible [2]. Tunnistamo uses the django-sass-processor package to do Sass preprocessing. That package uses the libsass library, which is deprecated and will never support any newer Sass syntax [3]. As a result, Tunnistamo is stuck with an old Sass syntax version unless the preprocessor system is changed to something more modern.

In this commit the bootstrap-sass is locked to version 3.4.1 which still uses the older syntax that libsass supports.

[1] https://github.com/twbs/bootstrap-sass/pull/1221
[2] https://sass-lang.com/documentation/breaking-changes/slash-div
[3] https://sass-lang.com/blog/libsass-is-deprecated