### PR TITLE
Split one mammoth test into multiple smaller ones

### DIFF
--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -348,7 +348,7 @@ LOGGING = {
     }
 }
 
-CORS_ORIGIN_ALLOW_ALL = False
+CORS_ALLOW_ALL_ORIGINS = False
 CORS_URLS_REGEX = r'.*/(\.well-known/openid-configuration|v1|openid|api-tokens|jwt-token).*'
 
 

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -98,7 +98,7 @@ def application_factory():
         kwargs.setdefault('name', get_random_string())
         kwargs.setdefault('client_id', get_random_string())
         kwargs.setdefault('user', None)
-        kwargs.setdefault('redirect_uris', None)
+        kwargs.setdefault('redirect_uris', '')
         kwargs.setdefault('client_type', Application.CLIENT_PUBLIC)
         kwargs.setdefault('authorization_grant_type', Application.GRANT_IMPLICIT)
 
@@ -113,7 +113,7 @@ def oidcclient_factory():
         kwargs.setdefault('name', get_random_string())
         kwargs.setdefault('client_type', 'public')
         kwargs.setdefault('client_id', get_random_string())
-        kwargs.setdefault('redirect_uris', None)
+        kwargs.setdefault('redirect_uris', list())
 
         response_types = kwargs.pop('response_types', ['id_token token'])
         instance = Client.objects.create(**kwargs)


### PR DESCRIPTION
The previous `test_cors_headers_got_with_whitelisted_uris_apiendpoints` test checked EVERYTHING related to the CORS headers. It was executed with various set of arguments and its behaviour was different according to those. It also contained needlessly complex logic that was very hard to read and understand.

Extracted the essence of that mammoth into smaller test functions. Now each test function checks one thing only. The meaning of each test function is now also documented in the function names.