### PR TITLE
Fetch users AD groups from the Microsoft Graph

### DIFF
--- a/auth_backends/helsinki_azure_ad.py
+++ b/auth_backends/helsinki_azure_ad.py
@@ -2,11 +2,11 @@ from functools import lru_cache
 
 from django.utils.translation import gettext, pgettext
 from requests import RequestException
-from social_core.backends.azuread_tenant import AzureADTenantOAuth2
+from social_core.backends.azuread_tenant import AzureADV2TenantOAuth2
 from social_core.exceptions import AuthFailed
 
 
-class HelsinkiAzureADTenantOAuth2(AzureADTenantOAuth2):
+class HelsinkiAzureADTenantOAuth2(AzureADV2TenantOAuth2):
     name = 'helsinkiazuread'
     name_baseform = gettext('Azure AD')
     name_access = pgettext('access to []', 'Azure AD')

--- a/auth_backends/tests/azure_ad_base.py
+++ b/auth_backends/tests/azure_ad_base.py
@@ -1,0 +1,170 @@
+import json
+from time import time
+
+import jwt
+import pytest
+from django.conf import settings
+from httpretty import HTTPretty
+from jwt.algorithms import RSAAlgorithm
+from social_core.backends.utils import load_backends
+from social_core.tests.backends.oauth import OAuth2Test
+from social_core.tests.backends.test_azuread_b2c import RSA_PRIVATE_JWT_KEY
+from social_core.tests.strategy import TestStrategy
+from social_core.utils import module_member
+from social_django.models import DjangoStorage
+
+CLIENT_ID = 'test-client-id'
+TENANT_ID = 'dummy-tenant-id'
+EXPIRES_IN = 3600
+
+
+def _generate_access_token_body(extra_payload=None):
+    auth_time = int(time())
+    expires_on = auth_time + EXPIRES_IN
+
+    payload = {
+        'aud': CLIENT_ID,
+        'iss': 'https://sts.windows.net/00000000-0000-0000-0000-000000000000/',
+        'iat': auth_time,
+        'nbf': auth_time,
+        'exp': expires_on,
+        'auth_time': auth_time,
+        'email': 'foobar@example.com',
+        'family_name': 'Bar',
+        'given_name': 'Foo',
+        'name': 'Bar Foo',
+        'oid': '11223344-5566-7788-9999-aabbccddeeff',
+        'onprem_sid': 'S-1-5-21-21656339-0000000000-0000000000-00000',
+        'sub': 'v-T_abcdefgABCDEFGabcdefgABCDEFGabcdefgABCD',
+        'tid': TENANT_ID,
+        'unique_name': 'foobar@example.com',
+        'upn': 'foobar@example.com',
+    }
+    if extra_payload:
+        payload.update(extra_payload)
+
+    return json.dumps({
+        'access_token': 'foobar',
+        'token_type': 'bearer',
+        'id_token': jwt.encode(
+            key=RSAAlgorithm.from_jwk(json.dumps(RSA_PRIVATE_JWT_KEY)),
+            headers={
+                'kid': RSA_PRIVATE_JWT_KEY['kid'],
+            },
+            algorithm='RS256',
+            payload=payload
+        ),
+        'expires_in': EXPIRES_IN,
+        'expires_on': expires_on,
+        'not_before': auth_time,
+    })
+
+
+@pytest.mark.django_db
+class AzureADV2TenantOAuth2Test(OAuth2Test):
+    backend_path = 'social_core.backends.azuread_tenant.AzureADV2TenantOAuth2'
+    expected_username = 'Bar Foo'
+    access_token_body = _generate_access_token_body()
+
+    def extra_settings(self):
+        social_auth_pipeline = [
+            stage for stage in settings.SOCIAL_AUTH_PIPELINE if stage not in [
+                # Remove stages that are not compatible with the tests, but doesn't
+                # matter in this case.
+                'users.pipeline.get_user_uuid',
+                'users.pipeline.require_email',
+                'users.pipeline.create_tunnistamo_session',
+            ]
+        ]
+
+        return {
+            'SOCIAL_AUTH_' + self.name + '_KEY': CLIENT_ID,
+            'SOCIAL_AUTH_' + self.name + '_SECRET': 'a-secret-key',
+            'SOCIAL_AUTH_' + self.name + '_TENANT_ID': TENANT_ID,
+            'SOCIAL_AUTH_PIPELINE': social_auth_pipeline,
+            'SOCIAL_AUTH_PROTECTED_USER_FIELDS': settings.SOCIAL_AUTH_PROTECTED_USER_FIELDS,
+        }
+
+    def setup_graph_response(self, body=None, status=200):
+        if not hasattr(self.backend, 'USER_DATA_URL'):
+            return
+
+        if not body:
+            body = json.dumps({
+                '@odata.context': 'https://graph.microsoft.com/beta/$metadata#directoryObjects',
+                'value': [],
+            })
+
+        HTTPretty.register_uri(HTTPretty.GET, self.backend.USER_DATA_URL, status=status, body=body)
+
+    def setUp(self):
+        HTTPretty.enable(allow_net_connect=False)
+        Backend = module_member(self.backend_path)
+        # Changed storage to DjangoStorage to allow using our own User-model
+        self.strategy = TestStrategy(DjangoStorage)
+        self.backend = Backend(self.strategy, redirect_uri=self.complete_url)
+        self.name = self.backend.name.upper().replace('-', '_')
+        self.complete_url = self.strategy.build_absolute_uri(
+            self.raw_complete_url.format(self.backend.name)
+        )
+        backends = (
+            self.backend_path,
+            'social_core.tests.backends.test_broken.BrokenBackendAuth'
+        )
+
+        self.strategy.set_settings({
+            'SOCIAL_AUTH_AUTHENTICATION_BACKENDS': backends
+        })
+
+        self.strategy.set_settings(self.extra_settings())
+        # Force backends loading to trash PSA cache
+        load_backends(backends, force_load=True)
+
+        keys_url = f'https://login.microsoftonline.com/{TENANT_ID}/discovery/v2.0/keys'
+        keys_body = json.dumps({
+            'keys': [{
+                # Dummy public key that pairs with `access_token_body` key:
+                # https://github.com/jpadilla/pyjwt/blob/06f461a/tests/keys/jwk_rsa_pub.json
+                'kty': 'RSA',
+                'kid': 'bilbo.baggins@hobbiton.example',
+                'use': 'sig',
+                'n': 'n4EPtAOCc9AlkeQHPzHStgAbgs7bTZLwUBZdR8_KuKPEHLd4rHVTeT-O-X'
+                     'V2jRojdNhxJWTDvNd7nqQ0VEiZQHz_AJmSCpMaJMRBSFKrKb2wqVwGU_Ns'
+                     'YOYL-QtiWN2lbzcEe6XC0dApr5ydQLrHqkHHig3RBordaZ6Aj-oBHqFEHY'
+                     'pPe7Tpe-OfVfHd1E6cS6M1FZcD1NNLYD5lFHpPI9bTwJlsde3uhGqC0ZCu'
+                     'EHg8lhzwOHrtIQbS0FVbb9k3-tVTU4fg_3L_vniUFAKwuCLqKnS2BYwdq_'
+                     'mzSnbLY7h_qixoR7jig3__kRhuaxwUkRz5iaiQkqgc5gHdrNP5zw',
+                'e': 'AQAB',
+                # Self-signed certificate generated with the RSA_PRIVATE_JWT_KEY
+                # Issued To: C=FI, ST=Uusimaa, L=Helsinki, O=City of Helsinki, CN=example.com
+                # Issued By: C=FI, ST=Uusimaa, L=Helsinki, O=City of Helsinki, CN=example.com
+                # Issued On: Wed Jan 01 2020 06:00:00 GMT+0200 (EET)
+                # Expires On: Tue Jan 01 2030 06:00:00 GMT+0200 (EET)
+                'x5c': [
+                    'MIIDbDCCAlSgAwIBAgIUPadjV3nYZBVO6XKTdJzJvalghykwDQYJKoZIhv'
+                    'cNAQELBQAwYzELMAkGA1UEBhMCRkkxEDAOBgNVBAgMB1V1c2ltYWExETAP'
+                    'BgNVBAcMCEhlbHNpbmtpMRkwFwYDVQQKDBBDaXR5IG9mIEhlbHNpbmtpMR'
+                    'QwEgYDVQQDDAtleGFtcGxlLmNvbTAeFw0yMDAxMDEwNDAwMDBaFw0zMDAx'
+                    'MDEwNDAwMDBaMGMxCzAJBgNVBAYTAkZJMRAwDgYDVQQIDAdVdXNpbWFhMR'
+                    'EwDwYDVQQHDAhIZWxzaW5raTEZMBcGA1UECgwQQ2l0eSBvZiBIZWxzaW5r'
+                    'aTEUMBIGA1UEAwwLZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4'
+                    'IBDwAwggEKAoIBAQCfgQ+0A4Jz0CWR5Ac/MdK2ABuCzttNkvBQFl1Hz8q4'
+                    'o8Qct3isdVN5P475dXaNGiN02HElZMO813uepDRUSJlAfP8AmZIKkxokxE'
+                    'FIUqspvbCpXAZT82xg5gv5C2JY3aVvNwR7pcLR0CmvnJ1AuseqQceKDdEG'
+                    'it1pnoCP6gEeoUQdik97tOl7459V8d3UTpxLozUVlwPU00tgPmUUek8j1t'
+                    'PAmWx17e6EaoLRkK4QeDyWHPA4eu0hBtLQVVtv2Tf61VNTh+D/cv++eJQU'
+                    'ArC4IuoqdLYFjB2r+bNKdstjuH+qLGhHuOKDf/+RGG5rHBSRHPmJqJCSqB'
+                    'zmAd2s0/nPAgMBAAGjGDAWMBQGA1UdEQQNMAuCCWxvY2FsaG9zdDANBgkq'
+                    'hkiG9w0BAQsFAAOCAQEAhESdBbHzb5kxie2W3cItD7PPhuTdMsHsrNYkcw'
+                    'GTPfaQH6XAQ1xSwvyFE6GFdpaOgCdnEmJguOuAqu0KQA9K3tn8gH+oHuRJ'
+                    'tK/jzYZx3/VT2fvVLDcRbtGfEr8V50UKhx2VRvnp+j2hc0EkgD8GYoE6os'
+                    'zI3acumJe14vcr2O1JMK/ap/Z95FCPyDmZ+T+sMi3c30KczkxQdVPZfRcM'
+                    'ayy2PhxJKVzKcwBSFZ/HG5ENmDQ4YK3t2wCWmVWECfQBEG27d6Zh8qVIWO'
+                    'ZpuuNcsm1Z1Gt0pFFgQxTnZzlh2YahIziFtzMx9PRhVr8jR8BUuAB/k9st'
+                    'ExP0kqnnA5y/VQ=='
+                ],
+            }],
+        })
+        HTTPretty.register_uri(HTTPretty.GET, keys_url, status=200, body=keys_body)
+
+        self.setup_graph_response()

--- a/auth_backends/tests/test_helsinki_azure_ad.py
+++ b/auth_backends/tests/test_helsinki_azure_ad.py
@@ -1,0 +1,130 @@
+import json
+
+from auth_backends.tests.azure_ad_base import AzureADV2TenantOAuth2Test, _generate_access_token_body
+
+
+class TestNoErrorWhenADGroupsNotInTokenOrGraph(AzureADV2TenantOAuth2Test):
+    backend_path = 'auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2'
+    access_token_body = _generate_access_token_body(extra_payload={
+        'groups': None,
+    })
+
+    def setup_graph_response(self, **kwargs):
+        super().setup_graph_response(status=400)
+
+    def test_login(self):
+        user = self.do_login()
+
+        self.assertEqual(user.ad_groups.count(), 0)
+
+
+class TestADGroupsFromGraphResponse(AzureADV2TenantOAuth2Test):
+    backend_path = 'auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2'
+    access_token_body = _generate_access_token_body(extra_payload={
+        '_claim_names': {
+            'groups': 'src1'
+        },
+        '_claim_sources': {
+            'src1': {
+                'endpoint': (
+                    'https://graph.windows.net/00000000-0000-0000-0000-000000000000'
+                    '/users/00000000-0000-0000-0000-000000000000/getMemberObjects'
+                )
+            }
+        },
+    })
+
+    def setup_graph_response(self, **kwargs):
+        body = json.dumps({
+            '@odata.context': 'https://graph.microsoft.com/beta/$metadata#directoryObjects',
+            'value': [
+                {
+                    '@odata.type': '#microsoft.graph.group',
+                    'id': '00000000-0000-4000-a0000000000000000',
+                    'displayName': 'first_group',
+                    'securityEnabled': True,
+                },
+                {
+                    '@odata.type': '#microsoft.graph.group',
+                    'id': '00000000-0000-4000-a0000000000000001',
+                    'displayName': 'Second group',
+                    'securityEnabled': True,
+                },
+                {
+                    '@odata.type': '#microsoft.graph.group',
+                    'id': '00000000-0000-4000-a0000000000000002',
+                    'displayName': 'Third Group',
+                    'securityEnabled': False,
+                },
+            ],
+        })
+
+        super().setup_graph_response(body=body)
+
+    def test_login(self):
+        user = self.do_login()
+
+        self.assertCountEqual(
+            ['first_group', 'second group'],
+            user.ad_groups.values_list('name', flat=True)
+        )
+
+
+class TestADGroupsFromToken(AzureADV2TenantOAuth2Test):
+    backend_path = 'auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2'
+    access_token_body = _generate_access_token_body(extra_payload={
+        'groups': [
+            'In-claim group 1',
+            'In-claim group 2',
+        ],
+    })
+
+    def setup_graph_response(self, **kwargs):
+        super().setup_graph_response(status=400)
+
+    def test_login(self):
+        user = self.do_login()
+
+        self.assertCountEqual(
+            ['in-claim group 1', 'in-claim group 2'],
+            user.ad_groups.values_list('name', flat=True)
+        )
+
+
+class TestADGroupsFromGraphResponseWhenAlsoTokenHasGroups(AzureADV2TenantOAuth2Test):
+    backend_path = 'auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2'
+    access_token_body = _generate_access_token_body(extra_payload={
+        'groups': [
+            'In-claim group 1',
+            'In-claim group 2',
+        ],
+    })
+
+    def setup_graph_response(self, **kwargs):
+        body = json.dumps({
+            '@odata.context': 'https://graph.microsoft.com/beta/$metadata#directoryObjects',
+            'value': [
+                {
+                    '@odata.type': '#microsoft.graph.group',
+                    'id': '00000000-0000-4000-a0000000000000000',
+                    'displayName': 'first_group',
+                    'securityEnabled': True,
+                },
+                {
+                    '@odata.type': '#microsoft.graph.group',
+                    'id': '00000000-0000-4000-a0000000000000001',
+                    'displayName': 'Second group',
+                    'securityEnabled': True,
+                }
+            ],
+        })
+
+        super().setup_graph_response(body=body)
+
+    def test_login(self):
+        user = self.do_login()
+
+        self.assertCountEqual(
+            ['first_group', 'second group'],
+            user.ad_groups.values_list('name', flat=True)
+        )

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -163,6 +163,9 @@ def update_ad_groups(details, backend, user=None, *args, **kwargs):
     if not isinstance(backend, (BaseADFS, Tunnistamo, AzureADOAuth2)) or not user or 'ad_groups' not in details:
         return
 
+    if not details['ad_groups']:
+        details['ad_groups'] = []
+
     user.update_ad_groups(details['ad_groups'])
 
 

--- a/users/tests/test_logout_view.py
+++ b/users/tests/test_logout_view.py
@@ -294,7 +294,7 @@ def test_logout_redirect_to_azuread_logout(
 
     httpretty.register_uri(
         httpretty.GET,
-        'https://login.microsoftonline.com/fake-tenant-id/.well-known/openid-configuration',
+        'https://login.microsoftonline.com/fake-tenant-id/v2.0/.well-known/openid-configuration',
         body='''
         {
             "end_session_endpoint": "https://example.com/end-session"
@@ -341,7 +341,7 @@ def test_logout_redirect_to_last_used_ad(
 
     httpretty.register_uri(
         httpretty.GET,
-        'https://login.microsoftonline.com/fake-tenant-id/.well-known/openid-configuration',
+        'https://login.microsoftonline.com/fake-tenant-id/v2.0/.well-known/openid-configuration',
         body='''
         {
             "end_session_endpoint": "https://example.com/azuread/end-session"


### PR DESCRIPTION
In cases where the user had over 200 groups in Azure AD the provided claims didn't include "groups" claim at all, but included "Groups overage claim". In which case the helusers update_ad_groups-method used in
`users.pipeline.update_ad_groups` pipeline stage failed because it expects the claim to always being a list.

See https://docs.microsoft.com/en-us/azure/active-directory/develop/id-tokens#groups-overage-claim
for more information about the Group Overage Claim.

Example of Group Overage Claim:

```json
    "_claim_names": {
        "groups": "src1"
    },
    "_claim_sources": {
        "src1": {
            "endpoint": "https://graph.windows.net/00000000-0000-0000-0000-000000000000/users/00000000-0000-0000-0000-000000000000/getMemberObjects"
        }
    }
```

The endpoint mentioned in the `_claim_sources` doesn't seem to work with the access tokens available when logging in. Neither did the tokens acquired by using the `AzureADV2TenantOAuth2` backend. But the tokens acquired by it work with
Microsoft Graph.

It was then decided (with Ville K) to get the AD groups from the Microsoft Graph
in all cases even when the claims include the "groups" claim.

There are also a couple of tests for this functionality. They use the tests from
the social_core as a base.

Refs HP-1388