### PR TITLE
xmlsec 1.3.12 Removed Python 2 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -197,5 +197,5 @@ uritemplate==3.0.0
     # via coreapi
 urllib3==1.26.6
     # via requests
-xmlsec==1.3.9
+xmlsec==1.3.12
     # via python3-saml


### PR DESCRIPTION
https://github.com/mehcode/python-xmlsec/releases
