### PR TITLE
Fix Helsinki Azure AD backend backwards compatibility

### DIFF
--- a/auth_backends/helsinki_azure_ad.py
+++ b/auth_backends/helsinki_azure_ad.py
@@ -63,6 +63,10 @@ class HelsinkiAzureADTenantOAuth2(AzureADV2TenantOAuth2):
 
         return user_data
 
+    def get_user_id(self, details, response):
+        """Use subject (sub) claim as unique id."""
+        return response.get('sub')
+
     def get_user_details(self, response):
         details = super().get_user_details(response)
         details['ad_groups'] = response.get('groups')

--- a/auth_backends/tests/azure_ad_base.py
+++ b/auth_backends/tests/azure_ad_base.py
@@ -37,6 +37,7 @@ def _generate_access_token_body(extra_payload=None):
         'onprem_sid': 'S-1-5-21-21656339-0000000000-0000000000-00000',
         'sub': 'v-T_abcdefgABCDEFGabcdefgABCDEFGabcdefgABCD',
         'tid': TENANT_ID,
+        'preferred_username': 'foobar@example.com',
         'unique_name': 'foobar@example.com',
         'upn': 'foobar@example.com',
     }

--- a/auth_backends/tests/test_helsinki_azure_ad.py
+++ b/auth_backends/tests/test_helsinki_azure_ad.py
@@ -3,6 +3,19 @@ import json
 from auth_backends.tests.azure_ad_base import AzureADV2TenantOAuth2Test, _generate_access_token_body
 
 
+class TestSocialAuthOidFromSubClaim(AzureADV2TenantOAuth2Test):
+    backend_path = 'auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2'
+    access_token_body = _generate_access_token_body()
+
+    def test_login(self):
+        user = self.do_login()
+
+        self.assertEqual(
+            user.social_auth.first().uid,
+            'v-T_abcdefgABCDEFGabcdefgABCDEFGabcdefgABCD'
+        )
+
+
 class TestNoErrorWhenADGroupsNotInTokenOrGraph(AzureADV2TenantOAuth2Test):
     backend_path = 'auth_backends.helsinki_azure_ad.HelsinkiAzureADTenantOAuth2'
     access_token_body = _generate_access_token_body(extra_payload={

--- a/users/admin.py
+++ b/users/admin.py
@@ -20,9 +20,31 @@ from .models import LoginMethod, SessionElement, TunnistamoSession, User
 Application = get_application_model()
 
 
+class UserSocialAuthInline(admin.StackedInline):
+    model = UserSocialAuth
+    readonly_fields = ['provider', 'uid', 'get_extra_data']
+    exclude = ['extra_data']
+    extra = 0
+
+    def get_extra_data(self, obj=None):
+        if not obj or not obj.extra_data:
+            return ''
+
+        return mark_safe(f'<pre>{escape(json.dumps(obj.extra_data, indent=4))}</pre>')
+
+    get_extra_data.short_description = _('Extra data')
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
 class ExtendedUserAdmin(UserAdmin):
     search_fields = ['username', 'uuid', 'email', 'first_name', 'last_name']
     list_display = search_fields + ['is_active', 'is_staff', 'is_superuser']
+    inlines = [UserSocialAuthInline]
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = super(ExtendedUserAdmin, self).get_fieldsets(request, obj)


### PR DESCRIPTION
The base class was changed from AzureADTenantOAuth2 to AzureADV2TenantOAuth2
in the previous change. I somehow missed that the value in "preferred_username"
claim was different from the "sub" claim used in the old backend.

That change meant that Social Auth would create a new user for the users that
had previously logged in with the old backend.