### PR TITLE
Add id_token_hint parameter when redirecting to OIDC end session

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -299,9 +299,20 @@ class TunnistamoOidcEndSessionView(EndSessionView):
 
             request.session['oidc_backend_end_session_redirected'][backend.name] = True
 
-            end_session_url = '{}?{}'.format(end_session_endpoint, urlencode({
+            end_session_parameters = {
                 'post_logout_redirect_uri': request.build_absolute_uri(request.path)
-            }))
+            }
+
+            # Add id_token_hint to the end session url if the id_token is available
+            # in the extra_data
+            id_token = social_user.extra_data.get('id_token')
+            if id_token:
+                end_session_parameters['id_token_hint'] = id_token
+
+            end_session_url = '{}?{}'.format(
+                end_session_endpoint,
+                urlencode(end_session_parameters)
+            )
 
             return end_session_url
 


### PR DESCRIPTION
Pass id_token_hint in the url when redirecting users to the end session endpoint
of the IDP(s). The parameter is added because Keycloak erroneously thinks that
the parameter is required when using post_logout_redirect_uri.

In the OIDC specification the parameter is RECOMMENDED. See:

https://openid.net/specs/openid-connect-rpinitiated-1_0.html

Refs HP-1470