### PR TITLE
Use the same view in both OpenID configuration info paths

### DIFF
--- a/tunnistamo/tests/test_openid_configuration.py
+++ b/tunnistamo/tests/test_openid_configuration.py
@@ -1,0 +1,13 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_openid_configuration_is_consistent_between_paths(client):
+    root_config_url = reverse('root-provider-info')
+    oidc_provider_config_url = reverse('oidc_provider:provider-info')
+
+    root_config = client.get(root_config_url).json()
+    oidc_provider_config = client.get(oidc_provider_config_url).json()
+
+    assert root_config == oidc_provider_config

--- a/tunnistamo/urls.py
+++ b/tunnistamo/urls.py
@@ -80,6 +80,9 @@ urlpatterns = [
     re_path(r'^openid/token/?$', csrf_exempt(TunnistamoOidcTokenView.as_view()), name='token'),
     re_path(r'^openid/userinfo/?$', csrf_exempt(userinfo), name='userinfo'),
     re_path(r'^openid/introspect/?$', TunnistamoTokenIntrospectionView.as_view(), name='token-introspection'),
+    # This should shadow the openid-configuration path in the oidc_provider.urls so that
+    # the same TunnistamoOidcProviderInfoView is used in both root, and openid paths.
+    re_path(r'^openid/\.well-known/openid-configuration/?$', TunnistamoOidcProviderInfoView.as_view()),
     path('openid/', include(oidc_provider.urls, namespace='oidc_provider')),
     re_path(r'^\.well-known/openid-configuration/?$', TunnistamoOidcProviderInfoView.as_view(),
             name='root-provider-info'),


### PR DESCRIPTION
Only the root openid-configuration was changed When the back-channel log out capability was implemented. The openid-configuration in the openid path should use the same TunnistamoOidcProviderInfoView view.

Refs HP-1596