### PR TITLE
Update Pillow from 9.0.1 to 9.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -116,7 +116,7 @@ oauthlib==2.1.0
     #   django-oauth-toolkit
     #   requests-oauthlib
     #   social-auth-core
-pillow==9.0.1
+pillow==9.3.0
     # via -r requirements.in
 polib==1.1.0
     # via django-translation-checker


### PR DESCRIPTION
One more dependency update. Don't know how I missed this the last time.

Pillow has had three CVEs after the version 9.0.1:

- https://www.cvedetails.com/cve/CVE-2022-30595/
- https://www.cvedetails.com/cve/CVE-2022-45198/
- https://www.cvedetails.com/cve/CVE-2022-45199/

Refs HP-1672