### PR TITLE
Update Python future from 0.16.0 to 0.18.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,7 @@ drf-oidc-auth==0.9
     # via django-helusers
 ecdsa==0.14.1
     # via python-jose
-future==0.16.0
+future==0.18.3
     # via pyjwkest
 geoip2==2.9.0
     # via -r requirements.in


### PR DESCRIPTION
Fixes: https://www.cve.org/CVERecord?id=CVE-2022-40899