### PR TITLE
Redirect to social auth begin for reauthentication

### DIFF
--- a/users/views.py
+++ b/users/views.py
@@ -127,6 +127,10 @@ class LoginView(TemplateView):
         idp_hint = request.GET.get('idp_hint')
         login_methods = filter_login_methods_by_provider_ids_string(allowed_methods_for_client, idp_hint)
 
+        last_login_backend = request.session.get('social_auth_last_login_backend')
+        if last_login_backend in settings.ALWAYS_REAUTHENTICATE_BACKENDS:
+            login_methods = filter_login_methods_by_provider_ids_string(login_methods, last_login_backend)
+
         if login_methods is None:
             login_methods = LoginMethod.objects.all()
 


### PR DESCRIPTION
When reauthentication is required for an already authenticated user, instead of redirecting to the login view and possibly giving the user a chance to select a login method, make the choice on behalf of the user (using the previously used login method) and go directly to the social auth flow.

I chose to do this this way instead of using the new `idp_hint` parameter, because the `idp_hint` parameter kind of indicates the original callers wish, which isn't the case in this scenario. Reusing the same parameter for this purpose could mess up things, because it gets stored in the session and may get used later. The solution proposed in this PR basically skips the login view, without a roundtrip to the browser.