### PR TITLE
Tests for post login hook

### DIFF
--- a/oidc_apis/utils.py
+++ b/oidc_apis/utils.py
@@ -60,7 +60,7 @@ def after_userlogin_hook(request, user, client):
         if last_login_backend is not None:
             active_user_social_auth = user.social_auth.filter(provider=last_login_backend).first()
 
-        if ((last_login_backend is None and user is not None)
+        if (last_login_backend is None
                 or (active_user_social_auth and active_user_social_auth.provider not in allowed_providers)):
             django_user_logout(request)
             next_page = request.get_full_path()

--- a/oidc_apis/utils.py
+++ b/oidc_apis/utils.py
@@ -5,7 +5,6 @@ import oidc_provider
 from django.conf import settings
 from django.contrib.auth import logout as django_user_logout
 from django.contrib.auth.views import redirect_to_login
-from django.core.exceptions import PermissionDenied
 from social_django.models import UserSocialAuth
 
 from users.models import OidcClientOptions, TunnistamoSession
@@ -56,8 +55,6 @@ def after_userlogin_hook(request, user, client):
         client_options = OidcClientOptions.objects.get(oidc_client=client)
 
         allowed_methods = client_options.login_methods.all()
-        if allowed_methods is None:
-            raise PermissionDenied
 
         allowed_providers = set((x.provider_id for x in allowed_methods))
         if last_login_backend is not None:

--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -362,6 +362,30 @@ def start_oidc_authorize(
     return oidc_client
 
 
+def do_complete_oidc_authentication(
+    django_client,
+    oidcclient_factory,
+    backend_name=DummyFixedOidcBackend.name,
+    login_methods=None,
+    oidc_client_kwargs=None,
+    extra_authorize_params=None
+):
+    oidc_client = start_oidc_authorize(
+        django_client,
+        oidcclient_factory,
+        backend_name=backend_name,
+        login_methods=login_methods,
+        oidc_client_kwargs=oidc_client_kwargs,
+        extra_authorize_params=extra_authorize_params,
+    )
+
+    callback_url = reverse('social:complete', kwargs={'backend': backend_name})
+    state_value = django_client.session[f'{backend_name}_state']
+    django_client.get(callback_url, data={'state': state_value}, follow=True)
+
+    return oidc_client
+
+
 class DummyADFSBackend(BaseADFS):
     name = 'dummy_adfs'
     AUTHORIZATION_URL = 'https://dummyadfs.example.com/adfs/oauth2/authorize'


### PR DESCRIPTION
The `after_userlogin_hook` function in `oidc_apis/utils.py` contains some code that isn't covered by any tests. The tests in this PR is a guess what that code is supposed to achieve. Also cleaned up the hook function itself a little.