### PR TITLE
Consider idp_hint parameter in authorize endpoint

### DIFF
--- a/tunnistamo/auth_tools.py
+++ b/tunnistamo/auth_tools.py
@@ -1,0 +1,13 @@
+def filter_login_methods_by_provider_ids_string(login_methods, provider_ids):
+    if not login_methods or not provider_ids:
+        return login_methods
+
+    provider_ids = [provider_id.strip() for provider_id in provider_ids.split(',')]
+
+    result = [
+        login_method
+        for login_method in login_methods
+        if login_method.provider_id in provider_ids
+    ]
+
+    return result if result else login_methods

--- a/users/tests/test_tunnistamo_authorize_view.py
+++ b/users/tests/test_tunnistamo_authorize_view.py
@@ -17,6 +17,20 @@ from users.tests.conftest import (
 from users.views import TunnistamoOidcAuthorizeView
 
 
+@pytest.fixture
+def dummy_backend(settings):
+    create_rsa_key()
+
+    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
+        'users.tests.conftest.DummyFixedOidcBackend',
+    )
+    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_OIDC_ENDPOINT = 'https://dummy.example.com'
+    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_KEY = 'tunnistamo'
+    settings.EMAIL_EXEMPT_AUTH_BACKENDS = [DummyFixedOidcBackend.name]
+
+    reload_social_django_utils()
+
+
 @pytest.mark.parametrize('with_trailing_slash', (True, False))
 @pytest.mark.django_db
 def test_tunnistamo_authorize_view_is_used(client, with_trailing_slash):
@@ -251,19 +265,8 @@ def test_public_clients_ability_to_skip_consent(
 
 @pytest.mark.django_db
 def test_when_authentication_completes_then_redirect_url_contains_first_authz_query_parameter(
-    oidcclient_factory, settings
+    oidcclient_factory, dummy_backend
 ):
-    create_rsa_key()
-
-    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
-        'users.tests.conftest.DummyFixedOidcBackend',
-    )
-    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_OIDC_ENDPOINT = 'https://dummy.example.com'
-    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_KEY = 'tunnistamo'
-    settings.EMAIL_EXEMPT_AUTH_BACKENDS = [DummyFixedOidcBackend.name]
-
-    reload_social_django_utils()
-
     test_client = CancelExampleComRedirectClient()
 
     start_oidc_authorize(
@@ -314,19 +317,8 @@ def test_when_previously_authenticated_user_has_not_used_social_auth_then_user_i
 
 @pytest.mark.django_db
 def test_when_previously_authenticated_user_used_not_allowed_login_method_then_user_logged_out_and_redirected_to_login(
-    loginmethod_factory, oidcclient_factory, oidcclientoptions_factory, settings
+    loginmethod_factory, oidcclient_factory, oidcclientoptions_factory, dummy_backend
 ):
-    create_rsa_key()
-
-    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
-        'users.tests.conftest.DummyFixedOidcBackend',
-    )
-    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_OIDC_ENDPOINT = 'https://dummy.example.com'
-    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_KEY = 'tunnistamo'
-    settings.EMAIL_EXEMPT_AUTH_BACKENDS = [DummyFixedOidcBackend.name]
-
-    reload_social_django_utils()
-
     test_client = CancelExampleComRedirectClient()
 
     # Authenticate using one social auth backend
@@ -366,21 +358,10 @@ def test_when_previously_authenticated_user_used_not_allowed_login_method_then_u
 @pytest.mark.django_db
 @pytest.mark.parametrize('do_reauthentication', (True, False))
 def test_when_previously_authenticated_backend_requires_reauthentication_then_user_is_redirected_to_login(
-    do_reauthentication, oidcclient_factory, settings
+    do_reauthentication, oidcclient_factory, settings, dummy_backend
 ):
-    create_rsa_key()
-
-    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
-        'users.tests.conftest.DummyFixedOidcBackend',
-    )
-    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_OIDC_ENDPOINT = 'https://dummy.example.com'
-    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_KEY = 'tunnistamo'
-    settings.EMAIL_EXEMPT_AUTH_BACKENDS = [DummyFixedOidcBackend.name]
-
     if do_reauthentication:
         settings.ALWAYS_REAUTHENTICATE_BACKENDS = [DummyFixedOidcBackend.name]
-
-    reload_social_django_utils()
 
     test_client = CancelExampleComRedirectClient()
 

--- a/users/views.py
+++ b/users/views.py
@@ -28,6 +28,7 @@ from social_django.utils import load_backend, load_strategy
 
 from auth_backends.adfs.base import BaseADFS
 from oidc_apis.models import ApiScope
+from tunnistamo.auth_tools import filter_login_methods_by_provider_ids_string
 from tunnistamo.endpoints import (
     TunnistamoAuthorizeEndpoint, TunnistamoTokenEndpoint, TunnistamoTokenIntrospectionEndpoint
 )
@@ -84,21 +85,6 @@ def _get_allowed_login_methods_for_client_id(client_id):
     return allowed_methods
 
 
-def _filter_login_methods_by_provider_ids_string(login_methods, provider_ids):
-    if not login_methods or not provider_ids:
-        return login_methods
-
-    provider_ids = [provider_id.strip() for provider_id in provider_ids.split(',')]
-
-    result = [
-        login_method
-        for login_method in login_methods
-        if login_method.provider_id in provider_ids
-    ]
-
-    return result if result else login_methods
-
-
 class LoginView(TemplateView):
     template_name = "login.html"
 
@@ -108,7 +94,7 @@ class LoginView(TemplateView):
         allowed_methods_for_client = _get_allowed_login_methods_for_client_id(client_id)
 
         idp_hint = request.GET.get('idp_hint')
-        login_methods = _filter_login_methods_by_provider_ids_string(allowed_methods_for_client, idp_hint)
+        login_methods = filter_login_methods_by_provider_ids_string(allowed_methods_for_client, idp_hint)
 
         if login_methods is None:
             login_methods = LoginMethod.objects.all()


### PR DESCRIPTION
When a previously authenticated user authenticates using another OIDC client, it's checked that the login method that the user used before, is good also for this new client. If not, the user gets logged out first.

Now the login methods of the new OIDC client are first filtered with the `idp_hint` parameter, and only after that the check is made.