### PR TITLE
Duplicate social login fix

### DIFF
--- a/users/tests/conftest.py
+++ b/users/tests/conftest.py
@@ -264,7 +264,7 @@ class DummyFixedOidcBackend(DummyOidcBackendBase):
             'family_name': 'User',
             'given_name': 'Test',
             'name': 'Test User',
-            'sub': '00000000-0000-4000-b000-000000000000'
+            'sub': self.setting('SUB_VALUE', '00000000-0000-4000-b000-000000000000')
         }
 
     def get_json(self, url, *args, **kwargs):
@@ -273,7 +273,7 @@ class DummyFixedOidcBackend(DummyOidcBackendBase):
             id_token = create_id_token(
                 self,
                 nonce=nonce,
-                sub='00000000-0000-4000-b000-000000000000',
+                sub=self.setting('SUB_VALUE', '00000000-0000-4000-b000-000000000000'),
                 email_verified=False,
                 name='Test User',
                 given_name='User',

--- a/users/tests/test_pipeline.py
+++ b/users/tests/test_pipeline.py
@@ -1,0 +1,55 @@
+import pytest
+from django.contrib import auth
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+from social_core.exceptions import AuthFailed
+
+from tunnistamo.tests.conftest import create_rsa_key, reload_social_django_utils
+from users.tests.conftest import DummyFixedOidcBackend
+
+
+@pytest.fixture
+def dummy_backend(settings):
+    create_rsa_key()
+
+    settings.AUTHENTICATION_BACKENDS = settings.AUTHENTICATION_BACKENDS + (
+        'users.tests.conftest.DummyFixedOidcBackend',
+    )
+    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_OIDC_ENDPOINT = 'https://dummy.example.com'
+    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_KEY = 'tunnistamo'
+    settings.EMAIL_EXEMPT_AUTH_BACKENDS = [DummyFixedOidcBackend.name]
+
+    reload_social_django_utils()
+
+
+def request_social_complete(client):
+    state_value = get_random_string()
+    session = client.session
+    session[f'{DummyFixedOidcBackend.name}_state'] = state_value
+    session.save()
+
+    complete_url = reverse('social:complete', kwargs={
+        'backend': DummyFixedOidcBackend.name
+    })
+
+    return client.get(complete_url, data={'state': state_value}, follow=False)
+
+
+@pytest.mark.django_db
+def test_second_social_login_same_provider_different_uid(client, settings, dummy_backend):
+    # Log the user in by completing dummy backend auth
+    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_SUB_VALUE = 'first_sub_value'
+    request_social_complete(client)
+    user = auth.get_user(client)
+
+    # Change the sub value and complete dummy backend auth again
+    settings.SOCIAL_AUTH_DUMMYFIXEDOIDCBACKEND_SUB_VALUE = 'second_sub_value'
+
+    # The social login should fail because it shouldn't be possible to
+    # attach a second social login to the already logged-in user with the same backend
+    # but with a different user in the backend.
+    with pytest.raises(AuthFailed):
+        request_social_complete(client)
+
+    assert user.social_auth.count() == 1
+    assert not auth.get_user(client).is_authenticated


### PR DESCRIPTION
When the user was logged in with a backend that is in the
ALWAYS_REAUTHENTICATE_BACKENDS setting, there could be a case where
another log in with the same backend but with a different user would add
a second social auth to the user.

It happened if the user was still logged in to Tunnistamo but logged
out of the backend.

Refs HP-1934