### PR TITLE
Fix server error when ADFS doesn't return unique_name

### DIFF
--- a/auth_backends/adfs/helsinki.py
+++ b/auth_backends/adfs/helsinki.py
@@ -57,12 +57,12 @@ class HelsinkiADFS(BaseADFS):
                 attrs[out_name] = val
             attrs[out_name] = val
 
-        if 'last_first_name' in attrs:
+        if attrs['last_first_name'] and isinstance(attrs['last_first_name'], str):
             names = attrs['last_first_name'].split(' ')
             if 'first_name' not in attrs:
                 attrs['first_name'] = [names[0]]
             if 'last_name' not in attrs:
                 attrs['last_name'] = [' '.join(names[1:])]
-            del attrs['last_first_name']
+        del attrs['last_first_name']
 
         return attrs

--- a/auth_backends/adfs/helsinki_library_asko.py
+++ b/auth_backends/adfs/helsinki_library_asko.py
@@ -67,12 +67,12 @@ class HelsinkiLibraryAskoADFS(BaseADFS):
                 logger.debug(f"'{in_name}' not found in data")
             attrs[out_name] = val
 
-        if 'last_first_name' in attrs:
+        if attrs['last_first_name'] and isinstance(attrs['last_first_name'], str):
             names = attrs['last_first_name'].split(' ')
             if 'first_name' not in attrs:
                 attrs['first_name'] = [names[0]]
             if 'last_name' not in attrs:
                 attrs['last_name'] = [' '.join(names[1:])]
-            del attrs['last_first_name']
+        del attrs['last_first_name']
 
         return attrs


### PR DESCRIPTION
clean_attributes function tried to call split function on None.

That was because if "unique_name" was not in attrs_in the attribute mapping would set attrs['last_first_name'] to None and the following code only checked that the key exists in the dict before using attrs['last_first_name'] as a string.

Refs HP-1951