### PR TITLE
Fix bug where one AD group would be added as one char groups

### DIFF
--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -166,6 +166,8 @@ def update_ad_groups(details, backend, user=None, *args, **kwargs):
 
     if not details['ad_groups']:
         details['ad_groups'] = []
+    elif isinstance(details['ad_groups'], str):
+        details['ad_groups'] = [details['ad_groups']]
 
     user.update_ad_groups(details['ad_groups'])
 


### PR DESCRIPTION
If the AD returns "group" claim as a string instead of a list of strings the update_ad_groups function would add every char in the group name as a separate ADGroup.

Fixed by converting the string to a one element list of the string before calling user.update_ad_groups.

Refs HP-1953