### PR TITLE
Dockerfile: use netcat-openbsd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-install.sh \
       git \
       libxmlsec1-dev \
       libxml2-dev \
-      netcat \
+      netcat-openbsd \
       pkg-config \
     && pip install -U pip \
     && pip install --no-cache-dir  -r /app/requirements.txt \


### PR DESCRIPTION
Base image uses Debian bookworm which doesn't have the netcat package.