### PR TITLE
Add Github action for building and publishing an image

### DIFF
--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,50 @@
+name: Build and publish a container image
+
+on:
+  push:
+    branches:
+      - "develop"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # For backwards compatibility, prefix branch tags with `refs-heads-`
+          tags: |
+            type=ref,event=branch,prefix=refs-heads-
+
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          # Build only the `production` target from Dockerfile
+          target: production
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The action triggers on pushes to the `develop` branch. It builds a container image and pushes it to ghcr.io. Based largely on the example from Github's documentation [1].

There used to be actions that, among other things, also built and published a similar kind of image. But those were removed in commit 69b20c86.

[1] https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages

Here's a [test run](https://github.com/City-of-Helsinki/tunnistamo/actions/runs/6466728520) and the [resulting image](https://github.com/City-of-Helsinki/tunnistamo/pkgs/container/tunnistamo/136005397?tag=refs-heads-build-push-image).