### PR TITLE
HP-2279 | feat: try to associate user by keycloak UUID

### DIFF
--- a/auth_backends/tests/azure_ad_base.py
+++ b/auth_backends/tests/azure_ad_base.py
@@ -75,6 +75,7 @@ class AzureADV2TenantOAuth2Test(OAuth2Test):
                 'users.pipeline.get_user_uuid',
                 'users.pipeline.require_email',
                 'users.pipeline.create_tunnistamo_session',
+                'users.pipeline.association_by_keycloak_uuid',
             ]
         ]
 

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -482,6 +482,11 @@ SOCIAL_AUTH_PIPELINE = (
     # a similar email address.
     # 'social_core.pipeline.social_auth.associate_by_email',
 
+    # User might have a social account with another Keycloak provider. Some fields
+    # between Tunnistamo and Keycloak might not be in sync (e.g. email), so we'll use
+    # UUID to find the user, since UUID should be in sync.
+    'users.pipeline.association_by_keycloak_uuid',
+
     # Create a user account if we haven't found one yet.
     'social_core.pipeline.user.create_user',
 


### PR DESCRIPTION
User might have a social account with another Keycloak provider. Some fields between Tunnistamo and Keycloak might not be in sync (e.g. email), so we'll use UUID to attempt to find the user.