### PR TITLE
fix: increase helsinki azure AD group listing size

### DIFF
--- a/auth_backends/helsinki_azure_ad.py
+++ b/auth_backends/helsinki_azure_ad.py
@@ -18,7 +18,7 @@ class HelsinkiAzureADTenantOAuth2(AzureADV2TenantOAuth2):
     name_logged_in_to = pgettext('logged in to []', 'Azure AD')
     name_logout_from = pgettext('log out from []', 'Azure AD')
     name_goto = pgettext('go to []', 'Azure AD')
-    USER_DATA_URL = 'https://graph.microsoft.com/v1.0/me/memberOf?$select=id,displayName,securityEnabled'
+    USER_DATA_URL = 'https://graph.microsoft.com/v1.0/me/memberOf?$select=id,displayName,securityEnabled&$top=999'
 
     @property
     @lru_cache()


### PR DESCRIPTION
Microsoft Graph memberOf API defaults to page size of 100. Increase it to 999 like it is in helsinki-tunnistus-plugin as we have users who have 100+ groups.

Refs: HP-2432