### PR TITLE
HP-2461 | feat: pass keycloak action parameter through

### DIFF
--- a/auth_backends/helsinki_tunnistus_suomifi.py
+++ b/auth_backends/helsinki_tunnistus_suomifi.py
@@ -5,8 +5,9 @@ from auth_backends.backchannel_logout import OidcBackchannelLogoutMixin
 
 class HelsinkiTunnistus(OidcBackchannelLogoutMixin, OpenIdConnectAuth):
     """Authenticates the user against Keycloak proxying to suomi.fi
-       This is plain OIDC backend, except that it uses the Keycloak provided
-       user id ("sub" field) as the local user identifier.
+
+    This is plain OIDC backend, except that it uses the Keycloak provided
+    user id ("sub" field) as the local user identifier.
     """
     name = 'heltunnistussuomifi'
 
@@ -27,14 +28,16 @@ class HelsinkiTunnistus(OidcBackchannelLogoutMixin, OpenIdConnectAuth):
         #
         # This is done to relay the client_id to the Helsinki tunnistus Keycloak.
         # The session variable is set in the TunnistamoOidcAuthorizeView.get method.
-        original_client_id = self.strategy.request.session.get(
+        if original_client_id := self.strategy.request.session.get(
             "oidc_authorize_original_client_id"
-        )
-        if original_client_id:
+        ):
             extra_arguments["original_client_id"] = original_client_id
 
-        ui_locales = self.strategy.request.session.get("ui_locales")
-        if ui_locales:
+        # Keycloak action passthrough
+        if kc_action := self.strategy.request.session.get("oidc_authorize_kc_action"):
+            extra_arguments["kc_action"] = kc_action
+
+        if ui_locales := self.strategy.request.session.get("ui_locales"):
             extra_arguments["ui_locales"] = ui_locales
 
         return extra_arguments

--- a/users/views.py
+++ b/users/views.py
@@ -166,9 +166,9 @@ class TunnistamoOidcAuthorizeView(AuthorizeView):
     def get(self, request, *args, **kwargs):
         request.GET = _extend_scope_in_query_params(request.GET)
 
-        if request.GET.get('client_id'):
+        if client_id := request.GET.get("client_id"):
             try:
-                client = Client.objects.get(client_id=request.GET.get('client_id'))
+                client = Client.objects.get(client_id=client_id)
 
                 # Save the client_id to the session to be used in the HelsinkiTunnistus
                 # social auth backend.
@@ -177,6 +177,10 @@ class TunnistamoOidcAuthorizeView(AuthorizeView):
                 # We don't care if the client wasn't found because the client will be
                 # validated again in the parent get method.
                 pass
+
+        # Keycloak action passthrough
+        if kc_action := request.GET.get("kc_action"):
+            request.session["oidc_authorize_kc_action"] = kc_action
 
         return super().get(request, *args, **kwargs)
 


### PR DESCRIPTION
Running actions with keycloak is done using `kc_action` parameter. Here, we're just passing the action through so that a user can e.g. update the password on keycloak while the authentication still flows through tunnistamo.
