### PR TITLE
HP-2491 | return kc_action_status from Keycloak on authentication

### DIFF
--- a/tunnistamo/endpoints.py
+++ b/tunnistamo/endpoints.py
@@ -33,6 +33,22 @@ class TunnistamoSessionEndpointMixin:
 
 
 class TunnistamoAuthorizeEndpoint(TunnistamoSessionEndpointMixin, AuthorizeEndpoint):
+
+    def __init__(self, request):
+        super().__init__(request)
+
+        if kc_value := self.request.session.get("kc_action_status"):
+            self.params["kc_action_status"] = kc_value
+
+    def create_response_uri(self):
+        """Add the status of the Keycloak action the callback url."""
+        uri = super().create_response_uri()
+
+        if kc_value := self.params.get("kc_action_status"):
+            uri = add_params_to_url(uri, {"kc_action_status": kc_value})
+
+        return uri
+
     def _get_tunnistamo_session(self):
         tunnistamo_session_id = self.request.session.get("tunnistamo_session_id")
         if not tunnistamo_session_id:

--- a/tunnistamo/settings.py
+++ b/tunnistamo/settings.py
@@ -514,6 +514,9 @@ SOCIAL_AUTH_PIPELINE = (
 
     # Add loa to Tunnistamo Session
     'users.pipeline.add_loa_to_tunnistamo_session',
+
+    # Save status of the Keycloak action to session
+    'users.pipeline.save_kc_action_status_to_session',
 )
 
 ALLOW_DUPLICATE_EMAILS = env("ALLOW_DUPLICATE_EMAILS")

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -337,3 +337,18 @@ def associate_between_helsinki_on_prem_ad_and_azure_ad(backend, details, user=No
         return {
             'user': existing_social_auth.user,
         }
+
+
+def save_kc_action_status_to_session(backend, strategy, *args, **kwargs):
+    """When a Keycloak action status is present save it to the session."""
+    if isinstance(backend, (HelsinkiTunnus, HelsinkiTunnistus)) and (
+        kc_action_status := strategy.request_data().get("kc_action_status")
+    ):
+        logger.debug(
+            f"kc_action_status {kc_action_status} in pipeline. Backend: {backend.name}."
+        )
+        strategy.session_set("kc_action_status", kc_action_status)
+    else:
+        strategy.session_pop("kc_action_status")
+
+    return

--- a/users/pipeline.py
+++ b/users/pipeline.py
@@ -2,7 +2,7 @@ import logging
 import uuid
 
 from django.conf import settings
-from django.contrib.auth import get_user_model, logout
+from django.contrib.auth import REDIRECT_FIELD_NAME, get_user_model, logout
 from django.shortcuts import render
 from django.urls import reverse
 from helusers.utils import uuid_to_username
@@ -256,10 +256,10 @@ def check_existing_social_associations(backend, strategy, user=None, social=None
                      ' with a different user. Log out and fail the login.')
         # Save the existing next value from the session and add it back after log out
         # so that InterruptedSocialAuthMiddleware can redirect back to the OIDC client
-        next_url = strategy.session.get('next')
+        next_url = strategy.session_get(REDIRECT_FIELD_NAME)
         logout(request)
         if next_url:
-            strategy.session_set('next', next_url)
+            strategy.session_set(REDIRECT_FIELD_NAME, next_url)
 
         raise AuthFailed(backend, 'Duplicate login')
 


### PR DESCRIPTION
`kc_action_status` is used to indicate e.g. whether a requested password change was successful or not. It will be returned
from tunnistamo along with `code` and `state` to the callback url the same way keycloak does it. This should make a later
transtition to keycloak (by dropping tunnistamo from the middle) not require extra work for any logic using `kc_action_status`.

Upon login the `kc_action_status` is saved to the session from which it is then retrieved in `TunnistamoAuthorizeEndpoint`.