### PR TITLE
HP-2655 | fix: uwsgi has version mismatches with precompiled python libs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ FROM helsinkitest/python-node:3.9-14-slim AS staticbuilder
 RUN apt-install.sh \
       libxmlsec1-dev \
       libxml2-dev \
+      libxslt-dev \
+      zlib1g-dev \
       pkg-config \
       git \
       curl \
@@ -48,6 +50,8 @@ RUN apt-install.sh \
       git \
       libxmlsec1-dev \
       libxml2-dev \
+      libxslt-dev \
+      zlib1g-dev \
       netcat-openbsd \
       pkg-config \
     && pip install -U pip setuptools wheel \
@@ -74,6 +78,10 @@ RUN python manage.py compilemessages
 # =========================
 FROM appbase AS development
 # =========================
+
+USER root
+RUN apt-install.sh build-essential
+USER appuser
 
 COPY --chown=appuser:appuser requirements-dev.txt /app/requirements-dev.txt
 RUN pip install --no-cache-dir -r /app/requirements-dev.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,13 +52,13 @@ RUN apt-install.sh \
       pkg-config \
     && pip install -U pip setuptools wheel \
     && pip install --no-cache-dir  -r /app/requirements.txt \
-    && pip install --no-cache-dir  -r /app/requirements-prod.txt \
+    && UWSGI_PROFILE_OVERRIDE="ssl=false" pip install --no-cache-dir  -r /app/requirements-prod.txt \
     && apt-cleanup.sh build-essential pkg-config
 
 COPY docker-entrypoint.sh /app
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
-# STore static files under /var to not conflict with development volume mount
+# Store static files under /var to not conflict with development volume mount
 ENV STATIC_ROOT /var/tunnistamo/static
 ENV MEDIA_ROOT /var/tunnistamo/media
 ENV NODE_MODULES_ROOT /var/tunnistamo/node_modules

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,9 @@
 #
 #    pip-compile --strip-extras requirements-dev.in
 #
+--no-binary lxml
+--no-binary xmlsec
+
 argparse==1.4.0
     # via unittest2
 build==1.2.1

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -4,5 +4,8 @@
 #
 #    pip-compile --strip-extras requirements-prod.in
 #
+--no-binary lxml
+--no-binary xmlsec
+
 uwsgi==2.0.26
     # via -r requirements-prod.in

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,6 @@
+--no-binary xmlsec
+--no-binary lxml
+
 django<5.0
 django-multiselectfield
 django-oauth-toolkit<=2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,9 @@
 #
 #    pip-compile --strip-extras requirements.in
 #
+--no-binary lxml
+--no-binary xmlsec
+
 aiohttp==3.9.5
     # via geoip2
 aiosignal==1.3.1


### PR DESCRIPTION
Instead of using libxml2 we can use expat with uwsgi which avoids the version mismatch with precompiled python libraries.

Also ssl is not terminated by uwsgi, so the feature can be disabled.

Refs: HP-2655